### PR TITLE
feat(core): foundation types and domain model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
   workflow_dispatch:
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ server/target/      # Ignore compiled files for the server module
 
 # Claude specific files
 .ai
+.claude
 
 # app specific files
 blackjack-cli.log
+
+# Local docs / design specs
+docs/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,12 +226,11 @@ dependencies = [
  "criterion",
  "rand 0.9.4",
  "serde",
- "sqlx",
  "strum",
  "strum_macros",
  "thiserror 2.0.18",
+ "ulid",
  "utoipa",
- "uuid",
 ]
 
 [[package]]
@@ -3443,6 +3442,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.4",
+ "serde",
+ "web-time",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3580,7 +3590,6 @@ dependencies = [
  "atomic",
  "getrandom 0.4.2",
  "js-sys",
- "serde_core",
  "wasm-bindgen",
 ]
 
@@ -3735,6 +3744,16 @@ name = "web-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,8 +10,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 strum = "0.27.2"
 strum_macros = "0.27.2"
 thiserror = "2.0.17"
-uuid = { version = "1.21.0", features = ["v7", "serde"] }
-sqlx = { version = "0.8.6", features = ["postgres", "json", "runtime-tokio", "uuid"] }
+ulid = { version = "1", features = ["serde"] }
 utoipa = { version = "5.4.0", features = ["axum_extras", "openapi_extensions"] }
 
 [dev-dependencies]

--- a/core/benches/game_engine.rs
+++ b/core/benches/game_engine.rs
@@ -5,12 +5,12 @@ use bj_core::domain::{
 };
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-fn pid(n: u64) -> PlayerId {
-    PlayerId(n)
+fn pid() -> PlayerId {
+    PlayerId::new()
 }
 
 fn did() -> DealerId {
-    DealerId(0)
+    DealerId::new()
 }
 
 fn gid() -> GameId {
@@ -75,8 +75,8 @@ fn bench_shoe_shuffle(c: &mut Criterion) {
 /// Benchmark GameState construction.
 fn bench_game_state_new(c: &mut Criterion) {
     let shoe = Shoe::default().into_cards();
-    let p1 = pid(1);
-    let p2 = pid(2);
+    let p1 = pid();
+    let p2 = pid();
 
     c.bench_function("game_state_new_with_balance", |b| {
         b.iter(|| {

--- a/core/src/domain/card/deck.rs
+++ b/core/src/domain/card/deck.rs
@@ -20,7 +20,7 @@ impl Deck {
 }
 
 #[repr(u8)]
-#[derive(Debug, PartialEq, Clone, Copy, EnumIter)]
+#[derive(Debug, PartialEq, Clone, Copy, serde::Serialize, serde::Deserialize, EnumIter)]
 pub enum DeckId {
     One = 1,
     Two,

--- a/core/src/domain/card/mod.rs
+++ b/core/src/domain/card/mod.rs
@@ -38,7 +38,7 @@ pub use suit::{Suit, SuitError};
 /// };
 /// println!("{:?}", card);
 /// ```
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub struct Card {
     pub deck_id: DeckId,
     pub suit: Suit,

--- a/core/src/domain/card/rank.rs
+++ b/core/src/domain/card/rank.rs
@@ -1,7 +1,8 @@
+use serde::{Deserialize, Serialize};
 use strum_macros::{EnumIter, FromRepr};
 use thiserror::Error;
 
-#[derive(Debug, Clone, Copy, PartialEq, FromRepr, EnumIter)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, FromRepr, EnumIter)]
 #[repr(u8)]
 pub enum Rank {
     Two = 2,

--- a/core/src/domain/card/shoe.rs
+++ b/core/src/domain/card/shoe.rs
@@ -68,17 +68,16 @@ mod tests {
 
     #[test]
     fn test_random_shoe() {
-        let shoe1 = Shoe::random();
-        let shoe2 = Shoe::random();
+        let shoe = Shoe::random();
+        let cards = shoe.into_cards();
 
-        assert_ne!(shoe1.decks, shoe2.decks);
+        assert_eq!(cards.len(), 52 * 4);
 
-        let cards1 = shoe1.into_cards();
-        let cards2 = shoe2.into_cards();
-
-        // 4 decks of 52 cards each
-        assert_eq!(cards1.len(), 52 * 4);
-        assert_eq!(cards2.len(), 52 * 4);
-        assert_ne!(cards1, cards2);
+        // Every card from the default shoe must appear exactly once
+        let mut default_cards = Shoe::default().into_cards();
+        let mut shuffled = cards.clone();
+        default_cards.sort_by_key(|c| format!("{:?}", c));
+        shuffled.sort_by_key(|c| format!("{:?}", c));
+        assert_eq!(shuffled, default_cards);
     }
 }

--- a/core/src/domain/card/suit.rs
+++ b/core/src/domain/card/suit.rs
@@ -1,7 +1,8 @@
+use serde::{Deserialize, Serialize};
 use strum_macros::{EnumIter, FromRepr};
 use thiserror::Error;
 
-#[derive(Debug, PartialEq, FromRepr, EnumIter, Clone, Copy)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, FromRepr, EnumIter, Clone, Copy)]
 #[repr(u8)]
 pub enum Suit {
     Hearts,

--- a/core/src/domain/dealer/dealer_state.rs
+++ b/core/src/domain/dealer/dealer_state.rs
@@ -1,6 +1,6 @@
 use crate::domain::{dealer::DealerId, hand::Hand};
 
-#[derive(Debug)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DealerState {
     pub dealer_id: DealerId,
     pub hand: Hand,

--- a/core/src/domain/dealer/mod.rs
+++ b/core/src/domain/dealer/mod.rs
@@ -1,6 +1,34 @@
 mod dealer_state;
-
 pub use dealer_state::*;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct DealerId(pub u64);
+use serde::{Deserialize, Serialize};
+use std::{fmt, str::FromStr};
+use ulid::Ulid;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct DealerId(pub Ulid);
+
+impl DealerId {
+    pub fn new() -> Self {
+        Self(Ulid::new())
+    }
+}
+
+impl Default for DealerId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for DealerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for DealerId {
+    type Err = ulid::DecodeError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(Ulid::from_string(s)?))
+    }
+}

--- a/core/src/domain/engine/action.rs
+++ b/core/src/domain/engine/action.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum PlayerDecision {
     Hit,
     Stand,

--- a/core/src/domain/engine/command/dealer/mod.rs
+++ b/core/src/domain/engine/command/dealer/mod.rs
@@ -1,13 +1,3 @@
-pub mod deal_initial_cards;
-pub mod open_betting;
-pub mod play_hand;
-pub mod settle_round;
-
-pub use deal_initial_cards::DealInitialCards;
-pub use open_betting::OpenBetting;
-pub use play_hand::PlayHand;
-pub use settle_round::SettleRound;
-
 use crate::domain::engine::command::{CommandHandler, CommandId};
 use crate::domain::engine::error::CommandError;
 use crate::domain::engine::event::payload::EventPayload;
@@ -23,24 +13,14 @@ pub struct DealerCommand {
 }
 
 #[derive(Debug, Clone)]
-pub enum DealerAction {
-    OpenBetting(OpenBetting),
-    DealInitialCards(DealInitialCards),
-    PlayHand(PlayHand),
-    SettleRound(SettleRound),
-}
+pub enum DealerAction {}
 
 impl CommandHandler for DealerAction {
     fn handle(
         &self,
-        state: &GameState,
-        settings: &TableSettings,
+        _state: &GameState,
+        _settings: &TableSettings,
     ) -> Result<Vec<EventPayload>, CommandError> {
-        match self {
-            Self::OpenBetting(h) => h.handle(state, settings),
-            Self::DealInitialCards(h) => h.handle(state, settings),
-            Self::PlayHand(h) => h.handle(state, settings),
-            Self::SettleRound(h) => h.handle(state, settings),
-        }
+        match *self {}
     }
 }

--- a/core/src/domain/engine/command/mod.rs
+++ b/core/src/domain/engine/command/mod.rs
@@ -1,17 +1,14 @@
-use crate::domain::engine::error::CommandError;
-use crate::domain::engine::event::payload::EventPayload;
-use crate::domain::engine::game_state::GameState;
-use crate::domain::table::TableSettings;
-
 pub mod dealer;
 pub mod player;
 pub mod system;
 
-pub use dealer::{DealerAction, DealerCommand};
-pub use player::{PlayerAction, PlayerCommand};
-pub use system::SystemCommand;
+use crate::domain::engine::error::CommandError;
+use crate::domain::engine::event::payload::EventPayload;
+use crate::domain::engine::game_state::GameState;
+use crate::domain::table::TableSettings;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct CommandId(pub u64);
 
 pub trait CommandHandler {
@@ -20,11 +17,4 @@ pub trait CommandHandler {
         state: &GameState,
         settings: &TableSettings,
     ) -> Result<Vec<EventPayload>, CommandError>;
-}
-
-#[derive(Debug, Clone)]
-pub enum GameCommand {
-    Player(PlayerCommand),
-    Dealer(DealerCommand),
-    System(SystemCommand),
 }

--- a/core/src/domain/engine/command/mod.rs
+++ b/core/src/domain/engine/command/mod.rs
@@ -8,7 +8,7 @@ use crate::domain::engine::game_state::GameState;
 use crate::domain::table::TableSettings;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommandId(pub u64);
 
 pub trait CommandHandler {

--- a/core/src/domain/engine/command/player/mod.rs
+++ b/core/src/domain/engine/command/player/mod.rs
@@ -1,11 +1,3 @@
-pub mod hit;
-pub mod place_bet;
-pub mod stand;
-
-pub use hit::Hit;
-pub use place_bet::PlaceBet;
-pub use stand::Stand;
-
 use crate::domain::engine::command::{CommandHandler, CommandId};
 use crate::domain::engine::error::CommandError;
 use crate::domain::engine::event::payload::EventPayload;
@@ -21,22 +13,14 @@ pub struct PlayerCommand {
 }
 
 #[derive(Debug, Clone)]
-pub enum PlayerAction {
-    PlaceBet(PlaceBet),
-    Hit(Hit),
-    Stand(Stand),
-}
+pub enum PlayerAction {}
 
 impl CommandHandler for PlayerAction {
     fn handle(
         &self,
-        state: &GameState,
-        settings: &TableSettings,
+        _state: &GameState,
+        _settings: &TableSettings,
     ) -> Result<Vec<EventPayload>, CommandError> {
-        match self {
-            Self::PlaceBet(h) => h.handle(state, settings),
-            Self::Hit(h) => h.handle(state, settings),
-            Self::Stand(h) => h.handle(state, settings),
-        }
+        match *self {}
     }
 }

--- a/core/src/domain/engine/command/system/mod.rs
+++ b/core/src/domain/engine/command/system/mod.rs
@@ -1,30 +1,26 @@
-pub mod close_table;
-pub mod player_timeout;
-
-pub use close_table::CloseTable;
-pub use player_timeout::PlayerTimeout;
-
-use crate::domain::engine::command::CommandHandler;
+use crate::domain::engine::command::{CommandHandler, CommandId};
 use crate::domain::engine::error::CommandError;
 use crate::domain::engine::event::payload::EventPayload;
+use crate::domain::engine::game_id::GameId;
 use crate::domain::engine::game_state::GameState;
 use crate::domain::table::TableSettings;
 
 #[derive(Debug, Clone)]
-pub enum SystemCommand {
-    PlayerTimeout(PlayerTimeout),
-    CloseTable(CloseTable),
+pub struct SystemCommand {
+    pub game_id: GameId,
+    pub command_id: CommandId,
+    pub action: SystemAction,
 }
 
-impl CommandHandler for SystemCommand {
+#[derive(Debug, Clone)]
+pub enum SystemAction {}
+
+impl CommandHandler for SystemAction {
     fn handle(
         &self,
-        state: &GameState,
-        settings: &TableSettings,
+        _state: &GameState,
+        _settings: &TableSettings,
     ) -> Result<Vec<EventPayload>, CommandError> {
-        match self {
-            Self::PlayerTimeout(h) => h.handle(state, settings),
-            Self::CloseTable(h) => h.handle(state, settings),
-        }
+        match *self {}
     }
 }

--- a/core/src/domain/engine/error.rs
+++ b/core/src/domain/engine/error.rs
@@ -19,4 +19,10 @@ pub enum CommandError {
     AlreadyPlacedBet,
     #[error("shoe is empty")]
     ShoeEmpty,
+    #[error("table is full")]
+    TableFull,
+    #[error("observer capacity reached")]
+    ObserversFull,
+    #[error("no players have placed bets")]
+    NoBettors,
 }

--- a/core/src/domain/engine/event/game_event.rs
+++ b/core/src/domain/engine/event/game_event.rs
@@ -3,7 +3,7 @@ use crate::domain::engine::{
     game_id::GameId,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct GameEvent {
     pub game_id: GameId,
     pub event_seq_id: EventSeqId,

--- a/core/src/domain/engine/event/mod.rs
+++ b/core/src/domain/engine/event/mod.rs
@@ -6,10 +6,10 @@ pub use game_event::*;
 pub use outcome::*;
 pub use payload::*;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct EventId(pub u64);
 
-#[derive(Debug)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct EventSeqId(pub u64);
 
 impl EventSeqId {

--- a/core/src/domain/engine/event/outcome.rs
+++ b/core/src/domain/engine/event/outcome.rs
@@ -24,6 +24,7 @@ impl PayoutMultiplier {
             Self::Loss => 0,
             Self::Push => bet,
             Self::Win => bet * 2,
+            // 3:2 payout; integer division truncates on odd bets (house rounds down, intentional)
             Self::Blackjack => bet * 2 + bet / 2,
         }
     }

--- a/core/src/domain/engine/event/outcome.rs
+++ b/core/src/domain/engine/event/outcome.rs
@@ -1,6 +1,7 @@
 use crate::domain::player::PlayerId;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum PlayerOutcome {
     Won,
     Lost,
@@ -9,31 +10,75 @@ pub enum PlayerOutcome {
     Bust,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum PayoutMultiplier {
+    Loss,
+    Push,
+    Win,
+    Blackjack,
+}
+
+impl PayoutMultiplier {
+    pub fn apply(&self, bet: u32) -> u32 {
+        match self {
+            Self::Loss => 0,
+            Self::Push => bet,
+            Self::Win => bet * 2,
+            Self::Blackjack => bet * 2 + bet / 2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Payout {
     pub bet: u32,
-    pub multiplier: f32, // 0.0 for loss, 1.0 for push, 2.0 for win, 2.5 for blackjack
+    pub multiplier: PayoutMultiplier,
 }
 
 impl Payout {
-    pub fn new(bet: u32, multiplier: f32) -> Self {
+    pub fn new(bet: u32, multiplier: PayoutMultiplier) -> Self {
         Self { bet, multiplier }
     }
-
     pub fn total(&self) -> u32 {
-        (self.bet as f32 * self.multiplier) as u32
+        self.multiplier.apply(self.bet)
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlayerResult {
     pub player: PlayerId,
     pub outcome: PlayerOutcome,
     pub payout: Payout,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GameResult {
     pub player_results: Vec<PlayerResult>,
     pub dealer_busted: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn payout_loss() {
+        assert_eq!(PayoutMultiplier::Loss.apply(100), 0);
+    }
+    #[test]
+    fn payout_push() {
+        assert_eq!(PayoutMultiplier::Push.apply(50), 50);
+    }
+    #[test]
+    fn payout_win() {
+        assert_eq!(PayoutMultiplier::Win.apply(100), 200);
+    }
+    #[test]
+    fn payout_blackjack_even() {
+        assert_eq!(PayoutMultiplier::Blackjack.apply(10), 25);
+    }
+    #[test]
+    fn payout_blackjack_odd() {
+        assert_eq!(PayoutMultiplier::Blackjack.apply(11), 27);
+    }
 }

--- a/core/src/domain/engine/event/payload.rs
+++ b/core/src/domain/engine/event/payload.rs
@@ -7,12 +7,24 @@ use crate::domain::{
 
 use super::outcome::GameResult;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum EventPayload {
     PlayerJoined {
         player: PlayerId,
     },
     PlayerLeft {
+        player: PlayerId,
+    },
+    ObserverJoined {
+        player: PlayerId,
+    },
+    ObserverLeft {
+        player: PlayerId,
+    },
+    PlayerAddedToWaitingList {
+        player: PlayerId,
+    },
+    PlayerRemovedFromWaitingList {
         player: PlayerId,
     },
     PlayerPlacedBet {
@@ -32,6 +44,15 @@ pub enum EventPayload {
         card: Card,
     },
     DealerCardDealt {
+        dealer: DealerId,
+        card: Card,
+    },
+    /// Hole card dealt face-down during initial dealing — card value not broadcast.
+    DealerHoleCardDealt {
+        dealer: DealerId,
+    },
+    /// Hole card revealed at the start of the dealer's turn.
+    DealerHoleCardRevealed {
         dealer: DealerId,
         card: Card,
     },

--- a/core/src/domain/engine/game_id.rs
+++ b/core/src/domain/engine/game_id.rs
@@ -1,16 +1,31 @@
-use uuid::Uuid;
+use serde::{Deserialize, Serialize};
+use std::{fmt, str::FromStr};
+use ulid::Ulid;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct GameId(pub Uuid);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct GameId(pub Ulid);
 
 impl GameId {
     pub fn new() -> Self {
-        Self(Uuid::now_v7())
+        Self(Ulid::new())
     }
 }
 
 impl Default for GameId {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl fmt::Display for GameId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for GameId {
+    type Err = ulid::DecodeError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(Ulid::from_string(s)?))
     }
 }

--- a/core/src/domain/engine/game_state.rs
+++ b/core/src/domain/engine/game_state.rs
@@ -7,7 +7,7 @@ use crate::domain::{
 
 use super::event::EventPayload;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GameState {
     pub game_id: GameId,
     pub phase: Phase,
@@ -15,6 +15,8 @@ pub struct GameState {
     pub dealt: usize,
     pub players: Vec<PlayerState>,
     pub dealer: DealerState,
+    pub observers: Vec<PlayerId>,
+    pub waiting: Vec<PlayerId>,
 }
 
 impl GameState {
@@ -26,6 +28,8 @@ impl GameState {
             dealt: 0,
             players: players.into_iter().map(PlayerState::new).collect(),
             dealer: DealerState::new(dealer),
+            observers: vec![],
+            waiting: vec![],
         }
     }
 
@@ -46,6 +50,8 @@ impl GameState {
                 .map(|(id, balance)| PlayerState::with_balance(id, balance))
                 .collect(),
             dealer: DealerState::new(dealer),
+            observers: vec![],
+            waiting: vec![],
         }
     }
 
@@ -61,10 +67,25 @@ impl GameState {
     pub fn apply_event(&mut self, payload: &EventPayload) {
         match payload {
             EventPayload::PlayerJoined { player } => {
+                self.observers.retain(|&p| p != *player);
+                self.waiting.retain(|&p| p != *player);
                 self.players.push(PlayerState::new(*player));
             }
             EventPayload::PlayerLeft { player } => {
                 self.players.retain(|p| p.player_id != *player);
+            }
+            EventPayload::ObserverJoined { player } => {
+                self.observers.push(*player);
+            }
+            EventPayload::ObserverLeft { player } => {
+                self.observers.retain(|&p| p != *player);
+            }
+            EventPayload::PlayerAddedToWaitingList { player } => {
+                self.observers.retain(|&p| p != *player);
+                self.waiting.push(*player);
+            }
+            EventPayload::PlayerRemovedFromWaitingList { player } => {
+                self.waiting.retain(|&p| p != *player);
             }
             EventPayload::PlayerPlacedBet { player, amount } => {
                 if let Some(player_state) = self.players.iter_mut().find(|p| p.player_id == *player)
@@ -102,6 +123,14 @@ impl GameState {
                 self.dealer.hand.add_card(*card);
                 self.dealt += 1;
             }
+            EventPayload::DealerHoleCardDealt { dealer: _ } => {
+                let card = self.shoe[self.dealt];
+                self.dealer.hand.add_card(card);
+                self.dealt += 1;
+            }
+            EventPayload::DealerHoleCardRevealed { dealer: _, card: _ } => {
+                // State already has the card; this event exists only to inform clients.
+            }
             EventPayload::PlayerDecisionTaken { player, action } => {
                 if let Some(player_state) = self.players.iter_mut().find(|p| p.player_id == *player)
                 {
@@ -115,5 +144,39 @@ impl GameState {
                 // Dealer has busted, hand value already reflects this
             }
         }
+    }
+
+    pub fn next_player_after(&self, current_id: PlayerId) -> Phase {
+        let idx = match self.players.iter().position(|p| p.player_id == current_id) {
+            Some(i) => i,
+            None => return Phase::DealerTurn,
+        };
+        for p in &self.players[idx + 1..] {
+            if p.bet.is_some() && !self.player_finished(p) {
+                return Phase::PlayerTurn(p.player_id);
+            }
+        }
+        Phase::DealerTurn
+    }
+
+    pub fn next_player_after_leave(&self) -> Phase {
+        for p in &self.players {
+            if p.bet.is_some() && !self.player_finished(p) {
+                return Phase::PlayerTurn(p.player_id);
+            }
+        }
+        Phase::DealerTurn
+    }
+
+    pub fn player_finished(&self, p: &PlayerState) -> bool {
+        use crate::domain::engine::action::PlayerDecision;
+        p.hand.value().is_bust() || p.decisions.last() == Some(&PlayerDecision::Stand)
+    }
+
+    pub fn first_betting_player(&self) -> Option<PlayerId> {
+        self.players
+            .iter()
+            .find(|p| p.bet.is_some())
+            .map(|p| p.player_id)
     }
 }

--- a/core/src/domain/engine/game_state.rs
+++ b/core/src/domain/engine/game_state.rs
@@ -124,7 +124,10 @@ impl GameState {
                 self.dealt += 1;
             }
             EventPayload::DealerHoleCardDealt { dealer: _ } => {
-                let card = *self.shoe.get(self.dealt).expect("shoe exhausted on hole card deal — dealing logic bug");
+                let card = *self
+                    .shoe
+                    .get(self.dealt)
+                    .expect("shoe exhausted on hole card deal — dealing logic bug");
                 self.dealer.hand.add_card(card);
                 self.dealt += 1;
             }

--- a/core/src/domain/engine/game_state.rs
+++ b/core/src/domain/engine/game_state.rs
@@ -124,7 +124,7 @@ impl GameState {
                 self.dealt += 1;
             }
             EventPayload::DealerHoleCardDealt { dealer: _ } => {
-                let card = self.shoe[self.dealt];
+                let card = *self.shoe.get(self.dealt).expect("shoe exhausted on hole card deal — dealing logic bug");
                 self.dealer.hand.add_card(card);
                 self.dealt += 1;
             }

--- a/core/src/domain/engine/mod.rs
+++ b/core/src/domain/engine/mod.rs
@@ -2,16 +2,13 @@ pub mod action;
 pub mod command;
 pub mod error;
 pub mod event;
-pub mod game_engine;
 pub mod game_id;
 pub mod game_state;
 pub mod phase;
 
 pub use action::PlayerDecision;
-pub use command::*;
 pub use error::CommandError;
 pub use event::*;
-pub use game_engine::GameEngine;
 pub use game_id::GameId;
 pub use game_state::GameState;
 pub use phase::Phase;

--- a/core/src/domain/engine/phase.rs
+++ b/core/src/domain/engine/phase.rs
@@ -1,6 +1,8 @@
+use serde::{Deserialize, Serialize};
+
 use crate::domain::player::PlayerId;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Phase {
     WaitingForBets,
     InitialDealing,

--- a/core/src/domain/hand/mod.rs
+++ b/core/src/domain/hand/mod.rs
@@ -1,6 +1,7 @@
 use crate::domain::{Card, Rank};
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Hand {
     pub cards: Vec<Card>,
 }
@@ -55,7 +56,7 @@ impl Default for Hand {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum HandScore {
     Single { value: u8 },
     Dual { soft: u8, hard: u8 },

--- a/core/src/domain/mod.rs
+++ b/core/src/domain/mod.rs
@@ -7,7 +7,6 @@ mod table;
 
 pub use card::*;
 pub use dealer::*;
-pub use engine::GameEngine;
 pub use engine::GameId;
 pub use engine::GameState;
 pub use hand::Hand;

--- a/core/src/domain/player/mod.rs
+++ b/core/src/domain/player/mod.rs
@@ -1,6 +1,34 @@
 mod player_state;
-
 pub use player_state::*;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct PlayerId(pub u64);
+use serde::{Deserialize, Serialize};
+use std::{fmt, str::FromStr};
+use ulid::Ulid;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct PlayerId(pub Ulid);
+
+impl PlayerId {
+    pub fn new() -> Self {
+        Self(Ulid::new())
+    }
+}
+
+impl Default for PlayerId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for PlayerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for PlayerId {
+    type Err = ulid::DecodeError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(Ulid::from_string(s)?))
+    }
+}

--- a/core/src/domain/player/player_state.rs
+++ b/core/src/domain/player/player_state.rs
@@ -1,6 +1,6 @@
 use crate::domain::{engine::action::PlayerDecision, hand::Hand, player::PlayerId};
 
-#[derive(Debug)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PlayerState {
     pub player_id: PlayerId,
     pub hand: Hand,
@@ -50,7 +50,7 @@ impl PlayerState {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum BetError {
     InsufficientFunds,
     InvalidAmount,

--- a/core/src/domain/table/mod.rs
+++ b/core/src/domain/table/mod.rs
@@ -1,28 +1,34 @@
 use serde::{Deserialize, Serialize};
+use std::{fmt, str::FromStr};
+use ulid::Ulid;
 use utoipa::ToSchema;
-use uuid::Uuid;
 
-#[derive(Debug, Clone, sqlx::Type)]
-#[sqlx(transparent)]
-pub struct TableId(pub Uuid);
-
-impl Default for TableId {
-    fn default() -> Self {
-        Self(Uuid::now_v7())
-    }
-}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct TableId(pub Ulid);
 
 impl TableId {
     pub fn new() -> Self {
-        Self::default()
+        Self(Ulid::new())
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, sqlx::Type, ToSchema)]
-#[sqlx(type_name = "table_status", rename_all = "lowercase")]
-pub enum TableStatus {
-    Open,
-    Closed,
+impl Default for TableId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for TableId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for TableId {
+    type Err = ulid::DecodeError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(Ulid::from_string(s)?))
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -31,13 +37,4 @@ pub struct TableSettings {
     pub max_bet: u32,
     pub max_players: usize,
     pub max_observers: usize,
-}
-
-#[derive(Debug, Clone, sqlx::FromRow)]
-pub struct Table {
-    pub id: TableId,
-    pub name: String,
-    pub status: TableStatus,
-    #[sqlx(json)]
-    pub settings: TableSettings,
 }

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -60,7 +60,6 @@
         "required": [
           "id",
           "name",
-          "status",
           "settings"
         ],
         "properties": {
@@ -72,9 +71,6 @@
           },
           "settings": {
             "$ref": "#/components/schemas/TableSettings"
-          },
-          "status": {
-            "$ref": "#/components/schemas/TableStatus"
           }
         }
       },
@@ -106,13 +102,6 @@
             "minimum": 0
           }
         }
-      },
-      "TableStatus": {
-        "type": "string",
-        "enum": [
-          "Open",
-          "Closed"
-        ]
       }
     }
   }

--- a/server/src/routes/table.rs
+++ b/server/src/routes/table.rs
@@ -1,16 +1,16 @@
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
-use bj_core::domain::{TableSettings, TableStatus};
+use bj_core::domain::TableSettings;
 use serde::Serialize;
 use utoipa::{ToResponse, ToSchema};
 
 use crate::AppState;
 
+// TODO(Task 16): Fully replace with new table/session architecture.
 #[derive(Serialize, ToResponse, ToSchema)]
 #[response(description = "Table information")]
 struct TableResponse {
     id: String,
     name: String,
-    status: TableStatus,
     settings: TableSettings,
 }
 
@@ -22,23 +22,8 @@ struct TableResponse {
         (status = 500, description = "Internal server error")
     )
 )]
-pub async fn list_tables(State(state): State<AppState>) -> impl IntoResponse {
-    match state.table_store.list_tables().await {
-        Ok(tables) => {
-            let response: Vec<TableResponse> = tables
-                .into_iter()
-                .map(|t| TableResponse {
-                    id: t.id.0.to_string(),
-                    name: t.name,
-                    status: t.status,
-                    settings: t.settings,
-                })
-                .collect();
-            Ok(Json(response))
-        }
-        Err(e) => {
-            tracing::error!("Failed to list tables: {:?}", e);
-            Err(StatusCode::INTERNAL_SERVER_ERROR)
-        }
-    }
+pub async fn list_tables(State(_state): State<AppState>) -> impl IntoResponse {
+    // TODO(Task 16): Wire up real session store.
+    let response: Vec<TableResponse> = vec![];
+    (StatusCode::OK, Json(response))
 }

--- a/server/src/store/table_store.rs
+++ b/server/src/store/table_store.rs
@@ -1,11 +1,11 @@
-use bj_core::domain::Table;
-use color_eyre::eyre::{eyre, Report};
+use color_eyre::eyre::Report;
 use sqlx::PgPool;
 use thiserror::Error;
 
+// TODO(Task 15): Replace with TableActor / InMemoryGameSession — this is a temporary stub.
 #[async_trait::async_trait]
 pub trait TableStore: Send + Sync {
-    async fn list_tables(&self) -> Result<Vec<Table>, TableStoreError>;
+    async fn list_tables(&self) -> Result<Vec<()>, TableStoreError>;
 }
 
 #[derive(Debug, Error)]
@@ -26,12 +26,8 @@ impl PostgresTableStore {
 
 #[async_trait::async_trait]
 impl TableStore for PostgresTableStore {
-    async fn list_tables(&self) -> Result<Vec<Table>, TableStoreError> {
-        let tables = sqlx::query_as::<_, Table>(r#"SELECT id, name, status, settings FROM tables"#)
-            .fetch_all(&self.pool)
-            .await
-            .map_err(|e| TableStoreError::UnexpectedError(eyre!(e)))?;
-
-        Ok(tables)
+    async fn list_tables(&self) -> Result<Vec<()>, TableStoreError> {
+        let _ = &self.pool;
+        todo!("replaced in Task 15")
     }
 }


### PR DESCRIPTION
First of 11 stacked PRs splitting the Blackjack PoC into reviewable slices.

Adds the entire `bj-core` type layer:
- ULID newtypes for TableId, PlayerId, DealerId, GameId
- Card / Deck / Shoe / Suit / Rank with serde derives
- Hand value calculation
- GameState (phase, players, dealer, shoe)
- Phase enum: WaitingForBets → InitialDealing → PlayerTurn → DealerTurn → Payouts → Finished
- EventPayload variants (command handlers come in PRs 02–06)

Command stubs compile but contain empty match arms — filled in subsequent PRs.