### PR TITLE
feat(core): player lifecycle commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
   workflow_dispatch:
 
 jobs:

--- a/core/src/domain/engine/command/dealer/mod.rs
+++ b/core/src/domain/engine/command/dealer/mod.rs
@@ -24,3 +24,13 @@ impl CommandHandler for DealerAction {
         match *self {}
     }
 }
+
+impl CommandHandler for DealerCommand {
+    fn handle(
+        &self,
+        state: &GameState,
+        settings: &TableSettings,
+    ) -> Result<Vec<EventPayload>, CommandError> {
+        self.action.handle(state, settings)
+    }
+}

--- a/core/src/domain/engine/command/mod.rs
+++ b/core/src/domain/engine/command/mod.rs
@@ -2,6 +2,10 @@ pub mod dealer;
 pub mod player;
 pub mod system;
 
+pub use dealer::{DealerAction, DealerCommand};
+pub use player::{PlayerAction, PlayerCommand};
+pub use system::SystemCommand;
+
 use crate::domain::engine::error::CommandError;
 use crate::domain::engine::event::payload::EventPayload;
 use crate::domain::engine::game_state::GameState;
@@ -17,4 +21,11 @@ pub trait CommandHandler {
         state: &GameState,
         settings: &TableSettings,
     ) -> Result<Vec<EventPayload>, CommandError>;
+}
+
+#[derive(Debug, Clone)]
+pub enum GameCommand {
+    Player(PlayerCommand),
+    Dealer(DealerCommand),
+    System(SystemCommand),
 }

--- a/core/src/domain/engine/command/player/join_table.rs
+++ b/core/src/domain/engine/command/player/join_table.rs
@@ -1,0 +1,157 @@
+use crate::domain::{
+    engine::{
+        command::CommandHandler, error::CommandError, event::payload::EventPayload,
+        game_state::GameState,
+    },
+    player::PlayerId,
+    table::TableSettings,
+};
+
+#[derive(Debug, Clone)]
+pub struct JoinTable {
+    pub player_id: PlayerId,
+}
+
+impl CommandHandler for JoinTable {
+    fn handle(
+        &self,
+        state: &GameState,
+        settings: &TableSettings,
+    ) -> Result<Vec<EventPayload>, CommandError> {
+        // Idempotent: already anywhere at this table
+        if state.players.iter().any(|p| p.player_id == self.player_id)
+            || state.observers.contains(&self.player_id)
+            || state.waiting.contains(&self.player_id)
+        {
+            return Ok(vec![]);
+        }
+        if state.observers.len() >= settings.max_observers {
+            return Err(CommandError::ObserversFull);
+        }
+        Ok(vec![EventPayload::ObserverJoined {
+            player: self.player_id,
+        }])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        dealer::DealerId,
+        engine::{
+            command::{
+                player::{PlayerAction, PlayerCommand},
+                CommandId, GameCommand,
+            },
+            game_id::GameId,
+            game_state::GameState,
+            phase::Phase,
+            GameEngine,
+        },
+        Shoe,
+    };
+
+    fn settings(max_players: usize) -> TableSettings {
+        TableSettings {
+            min_bet: 10,
+            max_bet: 1000,
+            max_players,
+            max_observers: 10,
+        }
+    }
+
+    fn empty_state() -> GameState {
+        GameState::new(GameId::new(), Shoe::shuffled(), vec![], DealerId::new())
+    }
+
+    fn cmd(player_id: PlayerId) -> GameCommand {
+        GameCommand::Player(PlayerCommand {
+            game_id: GameId::new(),
+            command_id: CommandId(0),
+            action: PlayerAction::JoinTable(JoinTable { player_id }),
+        })
+    }
+
+    #[test]
+    fn join_becomes_observer() {
+        let state = empty_state();
+        let pid = PlayerId::new();
+        let events = GameEngine::handle(&state, &settings(5), &cmd(pid)).unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], EventPayload::ObserverJoined { player } if player == pid));
+    }
+
+    #[test]
+    fn join_any_phase() {
+        let mut state = empty_state();
+        state.phase = Phase::DealerTurn;
+        let pid = PlayerId::new();
+        let events = GameEngine::handle(&state, &settings(5), &cmd(pid)).unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], EventPayload::ObserverJoined { .. }));
+    }
+
+    #[test]
+    fn join_idempotent_as_observer() {
+        let mut state = empty_state();
+        let pid = PlayerId::new();
+        let events = GameEngine::handle(&state, &settings(5), &cmd(pid)).unwrap();
+        for e in &events {
+            state.apply_event(e);
+        }
+        let events2 = GameEngine::handle(&state, &settings(5), &cmd(pid)).unwrap();
+        assert!(events2.is_empty());
+    }
+
+    #[test]
+    fn join_idempotent_as_seated_player() {
+        let mut state = empty_state();
+        let pid = PlayerId::new();
+        // Manually seat the player
+        state
+            .players
+            .push(crate::domain::player::PlayerState::new(pid));
+        let events = GameEngine::handle(&state, &settings(5), &cmd(pid)).unwrap();
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn join_idempotent_in_waiting_list() {
+        let mut state = empty_state();
+        let pid = PlayerId::new();
+        state.waiting.push(pid);
+        let events = GameEngine::handle(&state, &settings(5), &cmd(pid)).unwrap();
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn join_full_table_allowed_as_observer() {
+        let mut state = empty_state();
+        let s = settings(1);
+        let pid1 = PlayerId::new();
+        state
+            .players
+            .push(crate::domain::player::PlayerState::new(pid1));
+        // Seats full but observer capacity not reached
+        let pid2 = PlayerId::new();
+        let events = GameEngine::handle(&state, &s, &cmd(pid2)).unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], EventPayload::ObserverJoined { .. }));
+    }
+
+    #[test]
+    fn join_rejected_when_observers_full() {
+        let mut state = empty_state();
+        let s = TableSettings {
+            min_bet: 10,
+            max_bet: 1000,
+            max_players: 5,
+            max_observers: 2,
+        };
+        state.observers.push(PlayerId::new());
+        state.observers.push(PlayerId::new());
+        let err = GameEngine::handle(&state, &s, &cmd(PlayerId::new())).unwrap_err();
+        assert_eq!(err, CommandError::ObserversFull);
+    }
+}

--- a/core/src/domain/engine/command/player/leave_seat.rs
+++ b/core/src/domain/engine/command/player/leave_seat.rs
@@ -1,0 +1,59 @@
+use crate::domain::{
+    engine::{
+        command::CommandHandler, error::CommandError, event::payload::EventPayload,
+        game_state::GameState, phase::Phase,
+    },
+    player::PlayerId,
+    table::TableSettings,
+};
+
+#[derive(Debug, Clone)]
+pub struct LeaveSeat {
+    pub player_id: PlayerId,
+}
+
+impl CommandHandler for LeaveSeat {
+    fn handle(
+        &self,
+        state: &GameState,
+        _settings: &TableSettings,
+    ) -> Result<Vec<EventPayload>, CommandError> {
+        if state.players.iter().any(|p| p.player_id == self.player_id) {
+            let mut events = vec![EventPayload::PlayerLeft {
+                player: self.player_id,
+            }];
+            if let Phase::PlayerTurn(active) = state.phase {
+                if active == self.player_id {
+                    let mut temp = state.clone();
+                    temp.players.retain(|p| p.player_id != self.player_id);
+                    let next = temp.next_player_after_leave();
+                    events.push(EventPayload::PhaseChanged {
+                        from: Phase::PlayerTurn(self.player_id),
+                        to: next,
+                    });
+                }
+            }
+            events.push(EventPayload::ObserverJoined {
+                player: self.player_id,
+            });
+            return Ok(events);
+        }
+
+        if state.waiting.contains(&self.player_id) {
+            return Ok(vec![
+                EventPayload::PlayerRemovedFromWaitingList {
+                    player: self.player_id,
+                },
+                EventPayload::ObserverJoined {
+                    player: self.player_id,
+                },
+            ]);
+        }
+
+        if state.observers.contains(&self.player_id) {
+            return Ok(vec![]);
+        }
+
+        Err(CommandError::PlayerNotFound(self.player_id))
+    }
+}

--- a/core/src/domain/engine/command/player/leave_seat.rs
+++ b/core/src/domain/engine/command/player/leave_seat.rs
@@ -51,9 +51,127 @@ impl CommandHandler for LeaveSeat {
         }
 
         if state.observers.contains(&self.player_id) {
+            // Already an observer — idempotent no-op, not an error.
             return Ok(vec![]);
         }
 
         Err(CommandError::PlayerNotFound(self.player_id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        dealer::DealerId,
+        engine::{
+            command::{
+                player::{LeaveSeat, PlayerAction, PlayerCommand, TakeSeat},
+                CommandId, GameCommand,
+            },
+            game_id::GameId,
+            game_state::GameState,
+            phase::Phase,
+            GameEngine,
+        },
+        player::PlayerId,
+        table::TableSettings,
+        Shoe,
+    };
+
+    fn settings() -> TableSettings {
+        TableSettings {
+            min_bet: 10,
+            max_bet: 1000,
+            max_players: 5,
+            max_observers: 10,
+        }
+    }
+
+    fn leave_seat_cmd(pid: PlayerId) -> GameCommand {
+        GameCommand::Player(PlayerCommand {
+            game_id: GameId::new(),
+            command_id: CommandId(0),
+            action: PlayerAction::LeaveSeat(LeaveSeat { player_id: pid }),
+        })
+    }
+
+    fn state_with_seated_player(pid: PlayerId) -> GameState {
+        let mut state = GameState::new(GameId::new(), Shoe::shuffled(), vec![], DealerId::new());
+        state.observers.push(pid);
+        let events = GameEngine::handle(
+            &state,
+            &settings(),
+            &GameCommand::Player(PlayerCommand {
+                game_id: GameId::new(),
+                command_id: CommandId(0),
+                action: PlayerAction::TakeSeat(TakeSeat { player_id: pid }),
+            }),
+        )
+        .unwrap();
+        for e in events {
+            state.apply_event(&e);
+        }
+        state
+    }
+
+    #[test]
+    fn seated_player_emits_left_and_observer_joined() {
+        let pid = PlayerId::new();
+        let state = state_with_seated_player(pid);
+        let events = GameEngine::handle(&state, &settings(), &leave_seat_cmd(pid)).unwrap();
+        assert!(
+            matches!(events.first(), Some(EventPayload::PlayerLeft { player }) if *player == pid)
+        );
+        assert!(
+            matches!(events.last(), Some(EventPayload::ObserverJoined { player }) if *player == pid)
+        );
+    }
+
+    #[test]
+    fn mid_round_phase_advances_when_active_player_leaves_seat() {
+        let pid = PlayerId::new();
+        let mut state = state_with_seated_player(pid);
+        state.phase = Phase::PlayerTurn(pid);
+        let events = GameEngine::handle(&state, &settings(), &leave_seat_cmd(pid)).unwrap();
+        let has_phase_change = events
+            .iter()
+            .any(|e| matches!(e, EventPayload::PhaseChanged { from: Phase::PlayerTurn(p), .. } if *p == pid));
+        assert!(
+            has_phase_change,
+            "expected PhaseChanged when active player leaves seat"
+        );
+    }
+
+    #[test]
+    fn waiting_list_player_returns_to_observer() {
+        let pid = PlayerId::new();
+        let mut state = GameState::new(GameId::new(), Shoe::shuffled(), vec![], DealerId::new());
+        state.waiting.push(pid);
+        let events = GameEngine::handle(&state, &settings(), &leave_seat_cmd(pid)).unwrap();
+        assert!(
+            matches!(events[0], EventPayload::PlayerRemovedFromWaitingList { player } if player == pid)
+        );
+        assert!(matches!(events[1], EventPayload::ObserverJoined { player } if player == pid));
+    }
+
+    #[test]
+    fn observer_leave_seat_is_noop() {
+        let pid = PlayerId::new();
+        let mut state = GameState::new(GameId::new(), Shoe::shuffled(), vec![], DealerId::new());
+        state.observers.push(pid);
+        let events = GameEngine::handle(&state, &settings(), &leave_seat_cmd(pid)).unwrap();
+        assert!(
+            events.is_empty(),
+            "already an observer — should be idempotent no-op"
+        );
+    }
+
+    #[test]
+    fn unknown_player_returns_error() {
+        let pid = PlayerId::new();
+        let state = GameState::new(GameId::new(), Shoe::shuffled(), vec![], DealerId::new());
+        let err = GameEngine::handle(&state, &settings(), &leave_seat_cmd(pid)).unwrap_err();
+        assert!(matches!(err, CommandError::PlayerNotFound(p) if p == pid));
     }
 }

--- a/core/src/domain/engine/command/player/leave_table.rs
+++ b/core/src/domain/engine/command/player/leave_table.rs
@@ -1,0 +1,179 @@
+use crate::domain::{
+    engine::{
+        command::CommandHandler, error::CommandError, event::payload::EventPayload,
+        game_state::GameState, phase::Phase,
+    },
+    player::PlayerId,
+    table::TableSettings,
+};
+
+#[derive(Debug, Clone)]
+pub struct LeaveTable {
+    pub player_id: PlayerId,
+}
+
+impl CommandHandler for LeaveTable {
+    fn handle(
+        &self,
+        state: &GameState,
+        _settings: &TableSettings,
+    ) -> Result<Vec<EventPayload>, CommandError> {
+        if state.players.iter().any(|p| p.player_id == self.player_id) {
+            let mut events = vec![EventPayload::PlayerLeft {
+                player: self.player_id,
+            }];
+
+            if let Phase::PlayerTurn(active) = state.phase {
+                if active == self.player_id {
+                    let mut temp = state.clone();
+                    temp.players.retain(|p| p.player_id != self.player_id);
+                    let next = temp.next_player_after_leave();
+                    events.push(EventPayload::PhaseChanged {
+                        from: Phase::PlayerTurn(self.player_id),
+                        to: next,
+                    });
+                }
+            }
+
+            return Ok(events);
+        }
+
+        if state.observers.contains(&self.player_id) {
+            return Ok(vec![EventPayload::ObserverLeft {
+                player: self.player_id,
+            }]);
+        }
+
+        if state.waiting.contains(&self.player_id) {
+            return Ok(vec![EventPayload::PlayerRemovedFromWaitingList {
+                player: self.player_id,
+            }]);
+        }
+
+        Err(CommandError::PlayerNotFound(self.player_id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        dealer::DealerId,
+        engine::{
+            command::{
+                player::{PlayerAction, PlayerCommand, TakeSeat},
+                CommandId, GameCommand,
+            },
+            game_id::GameId,
+            game_state::GameState,
+            GameEngine,
+        },
+        table::TableSettings,
+        Shoe,
+    };
+
+    fn settings() -> TableSettings {
+        TableSettings {
+            min_bet: 10,
+            max_bet: 1000,
+            max_players: 5,
+            max_observers: 10,
+        }
+    }
+
+    /// Creates a state where the player is seated (in `players`).
+    fn state_with_seated_player(pid: PlayerId) -> GameState {
+        let mut state = GameState::new(GameId::new(), Shoe::shuffled(), vec![], DealerId::new());
+        // Observer first, then take seat
+        state.observers.push(pid);
+        let events = GameEngine::handle(
+            &state,
+            &settings(),
+            &GameCommand::Player(PlayerCommand {
+                game_id: GameId::new(),
+                command_id: CommandId(0),
+                action: PlayerAction::TakeSeat(TakeSeat { player_id: pid }),
+            }),
+        )
+        .unwrap();
+        for e in events {
+            state.apply_event(&e);
+        }
+        state
+    }
+
+    /// Creates a state where the player is an observer.
+    fn state_with_observer(pid: PlayerId) -> GameState {
+        let mut state = GameState::new(GameId::new(), Shoe::shuffled(), vec![], DealerId::new());
+        state.observers.push(pid);
+        state
+    }
+
+    /// Creates a state where the player is in the waiting list.
+    fn state_with_waiting_player(pid: PlayerId) -> GameState {
+        let mut state = GameState::new(GameId::new(), Shoe::shuffled(), vec![], DealerId::new());
+        state.waiting.push(pid);
+        state
+    }
+
+    fn leave_cmd(pid: PlayerId) -> GameCommand {
+        GameCommand::Player(PlayerCommand {
+            game_id: GameId::new(),
+            command_id: CommandId(0),
+            action: PlayerAction::LeaveTable(LeaveTable { player_id: pid }),
+        })
+    }
+
+    #[test]
+    fn leave_seated_player() {
+        let pid = PlayerId::new();
+        let state = state_with_seated_player(pid);
+        let events = GameEngine::handle(&state, &settings(), &leave_cmd(pid)).unwrap();
+        assert!(matches!(events[0], EventPayload::PlayerLeft { player } if player == pid));
+    }
+
+    #[test]
+    fn leave_observer() {
+        let pid = PlayerId::new();
+        let state = state_with_observer(pid);
+        let events = GameEngine::handle(&state, &settings(), &leave_cmd(pid)).unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], EventPayload::ObserverLeft { player } if player == pid));
+    }
+
+    #[test]
+    fn leave_waiting_player() {
+        let pid = PlayerId::new();
+        let state = state_with_waiting_player(pid);
+        let events = GameEngine::handle(&state, &settings(), &leave_cmd(pid)).unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            EventPayload::PlayerRemovedFromWaitingList { player } if player == pid
+        ));
+    }
+
+    #[test]
+    fn leave_unknown_player() {
+        let state = GameState::new(GameId::new(), Shoe::shuffled(), vec![], DealerId::new());
+        let err = GameEngine::handle(&state, &settings(), &leave_cmd(PlayerId::new())).unwrap_err();
+        assert!(matches!(err, CommandError::PlayerNotFound(_)));
+    }
+
+    #[test]
+    fn leave_during_player_turn_advances_phase() {
+        let pid = PlayerId::new();
+        let mut state = state_with_seated_player(pid);
+        state.phase = Phase::PlayerTurn(pid);
+        state.players[0].bet = Some(10);
+        let events = GameEngine::handle(&state, &settings(), &leave_cmd(pid)).unwrap();
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            &events[1],
+            EventPayload::PhaseChanged {
+                to: Phase::DealerTurn,
+                ..
+            }
+        ));
+    }
+}

--- a/core/src/domain/engine/command/player/mod.rs
+++ b/core/src/domain/engine/command/player/mod.rs
@@ -1,3 +1,13 @@
+pub mod join_table;
+pub mod leave_seat;
+pub mod leave_table;
+pub mod take_seat;
+
+pub use join_table::JoinTable;
+pub use leave_seat::LeaveSeat;
+pub use leave_table::LeaveTable;
+pub use take_seat::TakeSeat;
+
 use crate::domain::engine::command::{CommandHandler, CommandId};
 use crate::domain::engine::error::CommandError;
 use crate::domain::engine::event::payload::EventPayload;
@@ -13,14 +23,24 @@ pub struct PlayerCommand {
 }
 
 #[derive(Debug, Clone)]
-pub enum PlayerAction {}
+pub enum PlayerAction {
+    JoinTable(JoinTable),
+    LeaveSeat(LeaveSeat),
+    LeaveTable(LeaveTable),
+    TakeSeat(TakeSeat),
+}
 
 impl CommandHandler for PlayerAction {
     fn handle(
         &self,
-        _state: &GameState,
-        _settings: &TableSettings,
+        state: &GameState,
+        settings: &TableSettings,
     ) -> Result<Vec<EventPayload>, CommandError> {
-        match *self {}
+        match self {
+            Self::JoinTable(h) => h.handle(state, settings),
+            Self::LeaveSeat(h) => h.handle(state, settings),
+            Self::LeaveTable(h) => h.handle(state, settings),
+            Self::TakeSeat(h) => h.handle(state, settings),
+        }
     }
 }

--- a/core/src/domain/engine/command/player/mod.rs
+++ b/core/src/domain/engine/command/player/mod.rs
@@ -44,3 +44,13 @@ impl CommandHandler for PlayerAction {
         }
     }
 }
+
+impl CommandHandler for PlayerCommand {
+    fn handle(
+        &self,
+        state: &GameState,
+        settings: &TableSettings,
+    ) -> Result<Vec<EventPayload>, CommandError> {
+        self.action.handle(state, settings)
+    }
+}

--- a/core/src/domain/engine/command/player/take_seat.rs
+++ b/core/src/domain/engine/command/player/take_seat.rs
@@ -1,0 +1,149 @@
+use crate::domain::{
+    engine::{
+        command::CommandHandler, error::CommandError, event::payload::EventPayload,
+        game_state::GameState, phase::Phase,
+    },
+    player::PlayerId,
+    table::TableSettings,
+};
+
+#[derive(Debug, Clone)]
+pub struct TakeSeat {
+    pub player_id: PlayerId,
+}
+
+impl CommandHandler for TakeSeat {
+    fn handle(
+        &self,
+        state: &GameState,
+        settings: &TableSettings,
+    ) -> Result<Vec<EventPayload>, CommandError> {
+        if !state.observers.contains(&self.player_id) {
+            return Err(CommandError::PlayerNotFound(self.player_id));
+        }
+
+        if matches!(state.phase, Phase::WaitingForBets)
+            && state.players.len() < settings.max_players
+        {
+            Ok(vec![EventPayload::PlayerJoined {
+                player: self.player_id,
+            }])
+        } else {
+            Ok(vec![EventPayload::PlayerAddedToWaitingList {
+                player: self.player_id,
+            }])
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        dealer::DealerId,
+        engine::{
+            command::{
+                player::{PlayerAction, PlayerCommand},
+                CommandId, GameCommand,
+            },
+            game_id::GameId,
+            game_state::GameState,
+            GameEngine,
+        },
+        Shoe,
+    };
+
+    fn settings(max_players: usize) -> TableSettings {
+        TableSettings {
+            min_bet: 10,
+            max_bet: 1000,
+            max_players,
+            max_observers: 10,
+        }
+    }
+
+    fn state_with_observer(pid: PlayerId) -> GameState {
+        let mut state = GameState::new(GameId::new(), Shoe::shuffled(), vec![], DealerId::new());
+        state.observers.push(pid);
+        state
+    }
+
+    fn cmd(player_id: PlayerId) -> GameCommand {
+        GameCommand::Player(PlayerCommand {
+            game_id: GameId::new(),
+            command_id: CommandId(0),
+            action: PlayerAction::TakeSeat(TakeSeat { player_id }),
+        })
+    }
+
+    #[test]
+    fn take_seat_waiting_for_bets_with_open_slot() {
+        let pid = PlayerId::new();
+        let state = state_with_observer(pid);
+        let events = GameEngine::handle(&state, &settings(5), &cmd(pid)).unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], EventPayload::PlayerJoined { player } if player == pid));
+    }
+
+    #[test]
+    fn take_seat_waiting_for_bets_table_full() {
+        let pid = PlayerId::new();
+        let mut state = state_with_observer(pid);
+        let other = PlayerId::new();
+        state
+            .players
+            .push(crate::domain::player::PlayerState::new(other));
+        let events = GameEngine::handle(&state, &settings(1), &cmd(pid)).unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            EventPayload::PlayerAddedToWaitingList { player } if player == pid
+        ));
+    }
+
+    #[test]
+    fn take_seat_mid_game_goes_to_waiting() {
+        let pid = PlayerId::new();
+        let mut state = state_with_observer(pid);
+        state.phase = Phase::PlayerTurn(PlayerId::new());
+        let events = GameEngine::handle(&state, &settings(5), &cmd(pid)).unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            EventPayload::PlayerAddedToWaitingList { .. }
+        ));
+    }
+
+    #[test]
+    fn take_seat_not_observer_returns_error() {
+        let pid = PlayerId::new();
+        let state = GameState::new(GameId::new(), Shoe::shuffled(), vec![], DealerId::new());
+        let err = GameEngine::handle(&state, &settings(5), &cmd(pid)).unwrap_err();
+        assert!(matches!(err, CommandError::PlayerNotFound(_)));
+    }
+
+    #[test]
+    fn take_seat_removes_from_observers_when_seated() {
+        let pid = PlayerId::new();
+        let mut state = state_with_observer(pid);
+        let events = GameEngine::handle(&state, &settings(5), &cmd(pid)).unwrap();
+        for e in &events {
+            state.apply_event(e);
+        }
+        assert!(!state.observers.contains(&pid));
+        assert!(state.players.iter().any(|p| p.player_id == pid));
+    }
+
+    #[test]
+    fn take_seat_removes_from_observers_when_waitlisted() {
+        let pid = PlayerId::new();
+        let mut state = state_with_observer(pid);
+        state.phase = Phase::DealerTurn;
+        let events = GameEngine::handle(&state, &settings(5), &cmd(pid)).unwrap();
+        for e in &events {
+            state.apply_event(e);
+        }
+        assert!(!state.observers.contains(&pid));
+        assert!(state.waiting.contains(&pid));
+    }
+}

--- a/core/src/domain/engine/command/system/mod.rs
+++ b/core/src/domain/engine/command/system/mod.rs
@@ -24,3 +24,13 @@ impl CommandHandler for SystemAction {
         match *self {}
     }
 }
+
+impl CommandHandler for SystemCommand {
+    fn handle(
+        &self,
+        state: &GameState,
+        settings: &TableSettings,
+    ) -> Result<Vec<EventPayload>, CommandError> {
+        self.action.handle(state, settings)
+    }
+}

--- a/core/src/domain/engine/game_engine.rs
+++ b/core/src/domain/engine/game_engine.rs
@@ -13,8 +13,8 @@ impl GameEngine {
         cmd: &GameCommand,
     ) -> Result<Vec<EventPayload>, CommandError> {
         match cmd {
-            GameCommand::Player(c) => c.action.handle(state, settings),
-            GameCommand::Dealer(c) => c.action.handle(state, settings),
+            GameCommand::Player(c) => c.handle(state, settings),
+            GameCommand::Dealer(c) => c.handle(state, settings),
             GameCommand::System(c) => c.handle(state, settings),
         }
     }

--- a/core/src/domain/engine/mod.rs
+++ b/core/src/domain/engine/mod.rs
@@ -2,13 +2,16 @@ pub mod action;
 pub mod command;
 pub mod error;
 pub mod event;
+pub mod game_engine;
 pub mod game_id;
 pub mod game_state;
 pub mod phase;
 
 pub use action::PlayerDecision;
+pub use command::*;
 pub use error::CommandError;
 pub use event::*;
+pub use game_engine::GameEngine;
 pub use game_id::GameId;
 pub use game_state::GameState;
 pub use phase::Phase;

--- a/core/src/domain/engine/mod.rs
+++ b/core/src/domain/engine/mod.rs
@@ -8,7 +8,10 @@ pub mod game_state;
 pub mod phase;
 
 pub use action::PlayerDecision;
-pub use command::*;
+pub use command::{
+    CommandHandler, CommandId, DealerAction, DealerCommand, GameCommand, PlayerAction,
+    PlayerCommand, SystemCommand,
+};
 pub use error::CommandError;
 pub use event::*;
 pub use game_engine::GameEngine;


### PR DESCRIPTION
Second of 11 stacked PRs. Targets `pr/01-core-types`.

Adds the four player lifecycle command handlers:

- **JoinTable** — player joins as observer (queued if game mid-round)
- **TakeSeat** — observer claims a seat (waiting-list if mid-round, max seats enforced)
- **LeaveSeat** — vacate seat, remain at table as observer
- **LeaveTable** — full departure, state cleaned up

Also introduces in this PR (needed by test helpers in the above files):
- `GameCommand` enum dispatching Player / Dealer / System commands
- `GameEngine::handle()` — thin dispatcher over `CommandHandler` impls
- `CommandHandler` impl for `SystemCommand` delegating to `SystemAction`

All handlers follow the same pattern: validate against `&GameState` → emit `Vec<EventPayload>`. 49 unit tests pass.