### PR TITLE
feat(core): betting phase commands

### DIFF
--- a/core/src/domain/engine/command/dealer/mod.rs
+++ b/core/src/domain/engine/command/dealer/mod.rs
@@ -1,3 +1,7 @@
+pub mod open_betting;
+
+pub use open_betting::OpenBetting;
+
 use crate::domain::engine::command::{CommandHandler, CommandId};
 use crate::domain::engine::error::CommandError;
 use crate::domain::engine::event::payload::EventPayload;
@@ -13,15 +17,19 @@ pub struct DealerCommand {
 }
 
 #[derive(Debug, Clone)]
-pub enum DealerAction {}
+pub enum DealerAction {
+    OpenBetting(OpenBetting),
+}
 
 impl CommandHandler for DealerAction {
     fn handle(
         &self,
-        _state: &GameState,
-        _settings: &TableSettings,
+        state: &GameState,
+        settings: &TableSettings,
     ) -> Result<Vec<EventPayload>, CommandError> {
-        match *self {}
+        match self {
+            Self::OpenBetting(h) => h.handle(state, settings),
+        }
     }
 }
 

--- a/core/src/domain/engine/command/dealer/open_betting.rs
+++ b/core/src/domain/engine/command/dealer/open_betting.rs
@@ -1,8 +1,10 @@
-use crate::domain::engine::command::CommandHandler;
-use crate::domain::engine::error::CommandError;
-use crate::domain::engine::event::payload::EventPayload;
-use crate::domain::engine::game_state::GameState;
-use crate::domain::table::TableSettings;
+use crate::domain::{
+    engine::{
+        command::CommandHandler, error::CommandError, event::payload::EventPayload,
+        game_state::GameState, phase::Phase,
+    },
+    table::TableSettings,
+};
 
 #[derive(Debug, Clone)]
 pub struct OpenBetting;
@@ -10,9 +12,140 @@ pub struct OpenBetting;
 impl CommandHandler for OpenBetting {
     fn handle(
         &self,
-        _state: &GameState,
-        _settings: &TableSettings,
+        state: &GameState,
+        settings: &TableSettings,
     ) -> Result<Vec<EventPayload>, CommandError> {
-        todo!("open betting handler")
+        match &state.phase {
+            Phase::WaitingForBets => Ok(vec![]),
+            Phase::Finished => {
+                let mut events = vec![];
+                let seats_available = settings.max_players.saturating_sub(state.players.len());
+                for &pid in state.waiting.iter().take(seats_available) {
+                    events.push(EventPayload::PlayerJoined { player: pid });
+                }
+                events.push(EventPayload::PhaseChanged {
+                    from: Phase::Finished,
+                    to: Phase::WaitingForBets,
+                });
+                Ok(events)
+            }
+            actual => Err(CommandError::WrongPhase {
+                actual: actual.clone(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        dealer::DealerId,
+        engine::{
+            command::{
+                dealer::{DealerAction, DealerCommand},
+                CommandId, GameCommand,
+            },
+            game_id::GameId,
+            GameEngine,
+        },
+        player::PlayerId,
+        table::TableSettings,
+        Shoe,
+    };
+
+    fn settings() -> TableSettings {
+        TableSettings {
+            min_bet: 10,
+            max_bet: 1000,
+            max_players: 5,
+            max_observers: 10,
+        }
+    }
+
+    fn cmd() -> GameCommand {
+        GameCommand::Dealer(DealerCommand {
+            game_id: GameId::new(),
+            command_id: CommandId(0),
+            action: DealerAction::OpenBetting(OpenBetting),
+        })
+    }
+
+    #[test]
+    fn open_betting_noop_when_already_waiting() {
+        let state = GameState::new(GameId::new(), Shoe::shuffled(), vec![], DealerId::new());
+        let events = GameEngine::handle(&state, &settings(), &cmd()).unwrap();
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn open_betting_from_finished() {
+        let mut state = GameState::new(GameId::new(), Shoe::shuffled(), vec![], DealerId::new());
+        state.phase = Phase::Finished;
+        let events = GameEngine::handle(&state, &settings(), &cmd()).unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            EventPayload::PhaseChanged {
+                to: Phase::WaitingForBets,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn open_betting_promotes_waiting_players() {
+        let mut state = GameState::new(GameId::new(), Shoe::shuffled(), vec![], DealerId::new());
+        state.phase = Phase::Finished;
+        let pid1 = PlayerId::new();
+        let pid2 = PlayerId::new();
+        state.waiting.push(pid1);
+        state.waiting.push(pid2);
+        let events = GameEngine::handle(&state, &settings(), &cmd()).unwrap();
+        // Two PlayerJoined + one PhaseChanged
+        assert_eq!(events.len(), 3);
+        assert!(matches!(events[0], EventPayload::PlayerJoined { player } if player == pid1));
+        assert!(matches!(events[1], EventPayload::PlayerJoined { player } if player == pid2));
+        assert!(matches!(
+            &events[2],
+            EventPayload::PhaseChanged {
+                to: Phase::WaitingForBets,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn open_betting_respects_max_players() {
+        let mut state = GameState::new(GameId::new(), Shoe::shuffled(), vec![], DealerId::new());
+        state.phase = Phase::Finished;
+        // Fill one seat
+        state
+            .players
+            .push(crate::domain::player::PlayerState::new(PlayerId::new()));
+        // Two waiting but max_players is 2 so only one slot left
+        let pid1 = PlayerId::new();
+        let pid2 = PlayerId::new();
+        state.waiting.push(pid1);
+        state.waiting.push(pid2);
+
+        let s = TableSettings {
+            min_bet: 10,
+            max_bet: 1000,
+            max_players: 2,
+            max_observers: 10,
+        };
+        let events = GameEngine::handle(&state, &s, &cmd()).unwrap();
+        // One PlayerJoined + PhaseChanged
+        assert_eq!(events.len(), 2);
+        assert!(matches!(events[0], EventPayload::PlayerJoined { player } if player == pid1));
+    }
+
+    #[test]
+    fn open_betting_wrong_phase() {
+        let mut state = GameState::new(GameId::new(), Shoe::shuffled(), vec![], DealerId::new());
+        state.phase = Phase::DealerTurn;
+        let err = GameEngine::handle(&state, &settings(), &cmd()).unwrap_err();
+        assert!(matches!(err, CommandError::WrongPhase { .. }));
     }
 }

--- a/core/src/domain/engine/command/player/mod.rs
+++ b/core/src/domain/engine/command/player/mod.rs
@@ -1,11 +1,13 @@
 pub mod join_table;
 pub mod leave_seat;
 pub mod leave_table;
+pub mod place_bet;
 pub mod take_seat;
 
 pub use join_table::JoinTable;
 pub use leave_seat::LeaveSeat;
 pub use leave_table::LeaveTable;
+pub use place_bet::PlaceBet;
 pub use take_seat::TakeSeat;
 
 use crate::domain::engine::command::{CommandHandler, CommandId};
@@ -27,6 +29,7 @@ pub enum PlayerAction {
     JoinTable(JoinTable),
     LeaveSeat(LeaveSeat),
     LeaveTable(LeaveTable),
+    PlaceBet(PlaceBet),
     TakeSeat(TakeSeat),
 }
 
@@ -40,6 +43,7 @@ impl CommandHandler for PlayerAction {
             Self::JoinTable(h) => h.handle(state, settings),
             Self::LeaveSeat(h) => h.handle(state, settings),
             Self::LeaveTable(h) => h.handle(state, settings),
+            Self::PlaceBet(h) => h.handle(state, settings),
             Self::TakeSeat(h) => h.handle(state, settings),
         }
     }

--- a/core/src/domain/engine/command/player/place_bet.rs
+++ b/core/src/domain/engine/command/player/place_bet.rs
@@ -1,9 +1,11 @@
-use crate::domain::engine::command::CommandHandler;
-use crate::domain::engine::error::CommandError;
-use crate::domain::engine::event::payload::EventPayload;
-use crate::domain::engine::game_state::GameState;
-use crate::domain::player::PlayerId;
-use crate::domain::table::TableSettings;
+use crate::domain::{
+    engine::{
+        command::CommandHandler, error::CommandError, event::payload::EventPayload,
+        game_state::GameState, phase::Phase,
+    },
+    player::PlayerId,
+    table::TableSettings,
+};
 
 #[derive(Debug, Clone)]
 pub struct PlaceBet {
@@ -14,9 +16,172 @@ pub struct PlaceBet {
 impl CommandHandler for PlaceBet {
     fn handle(
         &self,
-        _state: &GameState,
-        _settings: &TableSettings,
+        state: &GameState,
+        settings: &TableSettings,
     ) -> Result<Vec<EventPayload>, CommandError> {
-        todo!("place bet handler")
+        if !matches!(state.phase, Phase::WaitingForBets) {
+            return Err(CommandError::WrongPhase {
+                actual: state.phase.clone(),
+            });
+        }
+        let player = state
+            .players
+            .iter()
+            .find(|p| p.player_id == self.player_id)
+            .ok_or(CommandError::PlayerNotFound(self.player_id))?;
+        if player.bet.is_some() {
+            return Err(CommandError::AlreadyPlacedBet);
+        }
+        if self.amount < settings.min_bet {
+            return Err(CommandError::BetBelowMinimum {
+                min: settings.min_bet,
+                amount: self.amount,
+            });
+        }
+        if self.amount > settings.max_bet {
+            return Err(CommandError::BetAboveMaximum {
+                max: settings.max_bet,
+                amount: self.amount,
+            });
+        }
+        if self.amount > player.balance {
+            return Err(CommandError::InsufficientBalance {
+                balance: player.balance,
+                amount: self.amount,
+            });
+        }
+        Ok(vec![EventPayload::PlayerPlacedBet {
+            player: self.player_id,
+            amount: self.amount,
+        }])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        dealer::DealerId,
+        engine::{
+            command::{
+                player::{PlayerAction, PlayerCommand},
+                CommandId, GameCommand,
+            },
+            game_id::GameId,
+            game_state::GameState,
+            GameEngine,
+        },
+        player::PlayerId,
+        table::TableSettings,
+        Shoe,
+    };
+
+    fn settings() -> TableSettings {
+        TableSettings {
+            min_bet: 10,
+            max_bet: 500,
+            max_players: 5,
+            max_observers: 10,
+        }
+    }
+
+    fn state_with_player(pid: PlayerId, balance: u32) -> GameState {
+        GameState::new_with_balance(
+            GameId::new(),
+            Shoe::shuffled(),
+            vec![(pid, balance)],
+            DealerId::new(),
+        )
+    }
+
+    fn bet_cmd(pid: PlayerId, amount: u32) -> GameCommand {
+        GameCommand::Player(PlayerCommand {
+            game_id: GameId::new(),
+            command_id: CommandId(0),
+            action: PlayerAction::PlaceBet(PlaceBet {
+                player_id: pid,
+                amount,
+            }),
+        })
+    }
+
+    #[test]
+    fn place_bet_happy_path() {
+        let pid = PlayerId::new();
+        let state = state_with_player(pid, 1000);
+        let events = GameEngine::handle(&state, &settings(), &bet_cmd(pid, 100)).unwrap();
+        assert!(
+            matches!(events[0], EventPayload::PlayerPlacedBet { player, amount: 100 } if player == pid)
+        );
+    }
+
+    #[test]
+    fn place_bet_wrong_phase() {
+        let pid = PlayerId::new();
+        let mut state = state_with_player(pid, 1000);
+        state.phase = Phase::DealerTurn;
+        assert!(matches!(
+            GameEngine::handle(&state, &settings(), &bet_cmd(pid, 100)),
+            Err(CommandError::WrongPhase { .. })
+        ));
+    }
+
+    #[test]
+    fn place_bet_below_minimum() {
+        let pid = PlayerId::new();
+        let state = state_with_player(pid, 1000);
+        assert!(matches!(
+            GameEngine::handle(&state, &settings(), &bet_cmd(pid, 5)),
+            Err(CommandError::BetBelowMinimum { min: 10, amount: 5 })
+        ));
+    }
+
+    #[test]
+    fn place_bet_above_maximum() {
+        let pid = PlayerId::new();
+        let state = state_with_player(pid, 1000);
+        assert!(matches!(
+            GameEngine::handle(&state, &settings(), &bet_cmd(pid, 600)),
+            Err(CommandError::BetAboveMaximum {
+                max: 500,
+                amount: 600
+            })
+        ));
+    }
+
+    #[test]
+    fn place_bet_insufficient_balance() {
+        let pid = PlayerId::new();
+        let state = state_with_player(pid, 50);
+        assert!(matches!(
+            GameEngine::handle(&state, &settings(), &bet_cmd(pid, 100)),
+            Err(CommandError::InsufficientBalance {
+                balance: 50,
+                amount: 100
+            })
+        ));
+    }
+
+    #[test]
+    fn place_bet_already_placed() {
+        let pid = PlayerId::new();
+        let mut state = state_with_player(pid, 1000);
+        let events = GameEngine::handle(&state, &settings(), &bet_cmd(pid, 100)).unwrap();
+        for e in &events {
+            state.apply_event(e);
+        }
+        assert!(matches!(
+            GameEngine::handle(&state, &settings(), &bet_cmd(pid, 100)),
+            Err(CommandError::AlreadyPlacedBet)
+        ));
+    }
+
+    #[test]
+    fn place_bet_player_not_found() {
+        let state = GameState::new(GameId::new(), Shoe::shuffled(), vec![], DealerId::new());
+        assert!(matches!(
+            GameEngine::handle(&state, &settings(), &bet_cmd(PlayerId::new(), 100)),
+            Err(CommandError::PlayerNotFound(_))
+        ));
     }
 }


### PR DESCRIPTION
Third of 11 stacked PRs. Targets `pr/02-core-lifecycle`.

Adds the betting phase command handlers:

- **OpenBetting** (dealer) — transitions phase to `WaitingForBets`, opens the round for player bets
- **PlaceBet** (player) — validates: phase == WaitingForBets, player seated, bet within [min, max], balance ≥ amount; emits `BetPlaced`

66 unit tests pass.