### PR TITLE
feat(core): dealing and player action commands

### DIFF
--- a/core/src/domain/engine/command/dealer/deal_initial_cards.rs
+++ b/core/src/domain/engine/command/dealer/deal_initial_cards.rs
@@ -1,8 +1,10 @@
-use crate::domain::engine::command::CommandHandler;
-use crate::domain::engine::error::CommandError;
-use crate::domain::engine::event::payload::EventPayload;
-use crate::domain::engine::game_state::GameState;
-use crate::domain::table::TableSettings;
+use crate::domain::{
+    engine::{
+        command::CommandHandler, error::CommandError, event::payload::EventPayload,
+        game_state::GameState, phase::Phase,
+    },
+    table::TableSettings,
+};
 
 #[derive(Debug, Clone)]
 pub struct DealInitialCards;
@@ -10,9 +12,173 @@ pub struct DealInitialCards;
 impl CommandHandler for DealInitialCards {
     fn handle(
         &self,
-        _state: &GameState,
+        state: &GameState,
         _settings: &TableSettings,
     ) -> Result<Vec<EventPayload>, CommandError> {
-        todo!("deal initial cards handler")
+        if !matches!(state.phase, Phase::WaitingForBets) {
+            return Err(CommandError::WrongPhase {
+                actual: state.phase.clone(),
+            });
+        }
+        let bettors: Vec<_> = state.players.iter().filter(|p| p.bet.is_some()).collect();
+        if bettors.is_empty() {
+            return Err(CommandError::NoBettors);
+        }
+        let needed = 2 * (bettors.len() + 1);
+        if state.cards_remaining() < needed {
+            return Err(CommandError::ShoeEmpty);
+        }
+
+        let mut events = vec![EventPayload::GameStarted];
+        let mut idx = state.dealt;
+
+        // Round 1: one card to each player, then dealer
+        for p in &bettors {
+            events.push(EventPayload::PlayerCardDealt {
+                player: p.player_id,
+                card: state.shoe[idx],
+            });
+            idx += 1;
+        }
+        events.push(EventPayload::DealerCardDealt {
+            dealer: state.dealer.dealer_id,
+            card: state.shoe[idx],
+        });
+        idx += 1;
+
+        // Round 2: second card to each player, then dealer
+        for p in &bettors {
+            events.push(EventPayload::PlayerCardDealt {
+                player: p.player_id,
+                card: state.shoe[idx],
+            });
+            idx += 1;
+        }
+        // Second dealer card is the hole card — do not reveal in the event.
+        events.push(EventPayload::DealerHoleCardDealt {
+            dealer: state.dealer.dealer_id,
+        });
+
+        let first = bettors[0].player_id;
+        events.push(EventPayload::PhaseChanged {
+            from: Phase::InitialDealing,
+            to: Phase::PlayerTurn(first),
+        });
+
+        Ok(events)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        dealer::DealerId,
+        engine::{
+            command::{
+                dealer::{DealerAction, DealerCommand},
+                CommandId, GameCommand,
+            },
+            game_id::GameId,
+            game_state::GameState,
+            GameEngine,
+        },
+        player::PlayerId,
+        table::TableSettings,
+        Card, DeckId, Rank, Suit,
+    };
+
+    fn settings() -> TableSettings {
+        TableSettings {
+            min_bet: 10,
+            max_bet: 500,
+            max_players: 5,
+            max_observers: 10,
+        }
+    }
+
+    fn card(rank: Rank) -> Card {
+        Card {
+            deck_id: DeckId::One,
+            rank,
+            suit: Suit::Spades,
+        }
+    }
+
+    fn cmd() -> GameCommand {
+        GameCommand::Dealer(DealerCommand {
+            game_id: GameId::new(),
+            command_id: CommandId(0),
+            action: DealerAction::DealInitialCards(DealInitialCards),
+        })
+    }
+
+    fn state_with_bet(pid: PlayerId) -> GameState {
+        let shoe = vec![
+            card(Rank::King),
+            card(Rank::Seven), // round 1: player, dealer
+            card(Rank::Ace),
+            card(Rank::Three), // round 2: player, dealer
+        ];
+        let mut state =
+            GameState::new_with_balance(GameId::new(), shoe, vec![(pid, 1000)], DealerId::new());
+        state.players[0].bet = Some(100);
+        state
+    }
+
+    #[test]
+    fn deals_correct_event_count_one_player() {
+        let pid = PlayerId::new();
+        let state = state_with_bet(pid);
+        let events = GameEngine::handle(&state, &settings(), &cmd()).unwrap();
+        // GameStarted + 2 PlayerCardDealt + DealerCardDealt + DealerHoleCardDealt + PhaseChanged = 6
+        assert_eq!(events.len(), 6);
+    }
+
+    #[test]
+    fn first_event_is_game_started() {
+        let pid = PlayerId::new();
+        let state = state_with_bet(pid);
+        let events = GameEngine::handle(&state, &settings(), &cmd()).unwrap();
+        assert!(matches!(events[0], EventPayload::GameStarted));
+    }
+
+    #[test]
+    fn last_event_advances_to_player_turn() {
+        let pid = PlayerId::new();
+        let state = state_with_bet(pid);
+        let events = GameEngine::handle(&state, &settings(), &cmd()).unwrap();
+        assert!(matches!(
+            events.last().unwrap(),
+            EventPayload::PhaseChanged {
+                to: Phase::PlayerTurn(_),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn no_bettors_errors() {
+        let state = GameState::new(
+            GameId::new(),
+            crate::domain::Shoe::shuffled(),
+            vec![],
+            DealerId::new(),
+        );
+        assert!(matches!(
+            GameEngine::handle(&state, &settings(), &cmd()),
+            Err(CommandError::NoBettors)
+        ));
+    }
+
+    #[test]
+    fn wrong_phase_errors() {
+        let pid = PlayerId::new();
+        let mut state = state_with_bet(pid);
+        state.phase = Phase::DealerTurn;
+        assert!(matches!(
+            GameEngine::handle(&state, &settings(), &cmd()),
+            Err(CommandError::WrongPhase { .. })
+        ));
     }
 }

--- a/core/src/domain/engine/command/dealer/mod.rs
+++ b/core/src/domain/engine/command/dealer/mod.rs
@@ -1,5 +1,7 @@
+pub mod deal_initial_cards;
 pub mod open_betting;
 
+pub use deal_initial_cards::DealInitialCards;
 pub use open_betting::OpenBetting;
 
 use crate::domain::engine::command::{CommandHandler, CommandId};
@@ -18,6 +20,7 @@ pub struct DealerCommand {
 
 #[derive(Debug, Clone)]
 pub enum DealerAction {
+    DealInitialCards(DealInitialCards),
     OpenBetting(OpenBetting),
 }
 
@@ -28,6 +31,7 @@ impl CommandHandler for DealerAction {
         settings: &TableSettings,
     ) -> Result<Vec<EventPayload>, CommandError> {
         match self {
+            Self::DealInitialCards(h) => h.handle(state, settings),
             Self::OpenBetting(h) => h.handle(state, settings),
         }
     }

--- a/core/src/domain/engine/command/player/hit.rs
+++ b/core/src/domain/engine/command/player/hit.rs
@@ -1,9 +1,11 @@
-use crate::domain::engine::command::CommandHandler;
-use crate::domain::engine::error::CommandError;
-use crate::domain::engine::event::payload::EventPayload;
-use crate::domain::engine::game_state::GameState;
-use crate::domain::player::PlayerId;
-use crate::domain::table::TableSettings;
+use crate::domain::{
+    engine::{
+        action::PlayerDecision, command::CommandHandler, error::CommandError,
+        event::payload::EventPayload, game_state::GameState, phase::Phase,
+    },
+    player::PlayerId,
+    table::TableSettings,
+};
 
 #[derive(Debug, Clone)]
 pub struct Hit {
@@ -13,9 +15,161 @@ pub struct Hit {
 impl CommandHandler for Hit {
     fn handle(
         &self,
-        _state: &GameState,
+        state: &GameState,
         _settings: &TableSettings,
     ) -> Result<Vec<EventPayload>, CommandError> {
-        todo!("hit handler")
+        match &state.phase {
+            Phase::PlayerTurn(id) if *id == self.player_id => {}
+            _ => return Err(CommandError::NotPlayersTurn),
+        }
+        let card = state.next_card().ok_or(CommandError::ShoeEmpty)?;
+        let player = state
+            .players
+            .iter()
+            .find(|p| p.player_id == self.player_id)
+            .ok_or(CommandError::PlayerNotFound(self.player_id))?;
+
+        let mut events = vec![EventPayload::PlayerCardDealt {
+            player: self.player_id,
+            card,
+        }];
+
+        let mut new_hand = player.hand.clone();
+        new_hand.add_card(card);
+
+        if new_hand.value().is_bust() {
+            events.push(EventPayload::PlayerBust {
+                player: self.player_id,
+            });
+            events.push(EventPayload::PhaseChanged {
+                from: Phase::PlayerTurn(self.player_id),
+                to: state.next_player_after(self.player_id),
+            });
+        } else if new_hand.value().best_value() == 21 {
+            // Auto-stand on 21
+            events.push(EventPayload::PlayerDecisionTaken {
+                player: self.player_id,
+                action: PlayerDecision::Stand,
+            });
+            events.push(EventPayload::PhaseChanged {
+                from: Phase::PlayerTurn(self.player_id),
+                to: state.next_player_after(self.player_id),
+            });
+        }
+
+        Ok(events)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        dealer::DealerId,
+        engine::{
+            command::{
+                player::{PlayerAction, PlayerCommand},
+                CommandId, GameCommand,
+            },
+            game_id::GameId,
+            game_state::GameState,
+            phase::Phase,
+            GameEngine,
+        },
+        player::PlayerId,
+        table::TableSettings,
+        Card, DeckId, Rank, Suit,
+    };
+
+    fn settings() -> TableSettings {
+        TableSettings {
+            min_bet: 10,
+            max_bet: 500,
+            max_players: 5,
+            max_observers: 10,
+        }
+    }
+
+    fn card(rank: Rank) -> Card {
+        Card {
+            deck_id: DeckId::One,
+            rank,
+            suit: Suit::Spades,
+        }
+    }
+
+    fn hit_cmd(pid: PlayerId) -> GameCommand {
+        GameCommand::Player(PlayerCommand {
+            game_id: GameId::new(),
+            command_id: CommandId(0),
+            action: PlayerAction::Hit(Hit { player_id: pid }),
+        })
+    }
+
+    fn state_in_player_turn(
+        pid: PlayerId,
+        hand_ranks: Vec<Rank>,
+        next_card_rank: Rank,
+    ) -> GameState {
+        // shoe: [next_card, padding...]
+        let mut shoe: Vec<Card> = vec![card(next_card_rank)];
+        shoe.extend(vec![card(Rank::Two); 20]);
+
+        let mut state =
+            GameState::new_with_balance(GameId::new(), shoe, vec![(pid, 1000)], DealerId::new());
+        state.players[0].bet = Some(100);
+        // Manually add hand cards (dealt = 0, so next_card is shoe[0])
+        for r in hand_ranks {
+            state.players[0].hand.add_card(card(r));
+        }
+        state.phase = Phase::PlayerTurn(pid);
+        state
+    }
+
+    #[test]
+    fn hit_deals_card_no_bust() {
+        let pid = PlayerId::new();
+        let state = state_in_player_turn(pid, vec![Rank::Two, Rank::Three], Rank::Four);
+        let events = GameEngine::handle(&state, &settings(), &hit_cmd(pid)).unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], EventPayload::PlayerCardDealt { .. }));
+    }
+
+    #[test]
+    fn hit_causes_bust() {
+        let pid = PlayerId::new();
+        // King(10) + Queen(10) in hand, next card Five(5) -> 25, bust
+        let state = state_in_player_turn(pid, vec![Rank::King, Rank::Queen], Rank::Five);
+        let events = GameEngine::handle(&state, &settings(), &hit_cmd(pid)).unwrap();
+        assert_eq!(events.len(), 3); // CardDealt + Bust + PhaseChanged
+        assert!(matches!(events[1], EventPayload::PlayerBust { .. }));
+        assert!(matches!(events[2], EventPayload::PhaseChanged { .. }));
+    }
+
+    #[test]
+    fn hit_reaches_21_auto_stand() {
+        let pid = PlayerId::new();
+        // King(10) + Eight(8) in hand, next Three(3) -> 21
+        let state = state_in_player_turn(pid, vec![Rank::King, Rank::Eight], Rank::Three);
+        let events = GameEngine::handle(&state, &settings(), &hit_cmd(pid)).unwrap();
+        assert_eq!(events.len(), 3); // CardDealt + DecisionTaken(Stand) + PhaseChanged
+        assert!(matches!(
+            events[1],
+            EventPayload::PlayerDecisionTaken {
+                action: PlayerDecision::Stand,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn hit_wrong_turn() {
+        let pid = PlayerId::new();
+        let other = PlayerId::new();
+        let state = state_in_player_turn(pid, vec![Rank::Two, Rank::Three], Rank::Four);
+        assert!(matches!(
+            GameEngine::handle(&state, &settings(), &hit_cmd(other)),
+            Err(CommandError::NotPlayersTurn)
+        ));
     }
 }

--- a/core/src/domain/engine/command/player/mod.rs
+++ b/core/src/domain/engine/command/player/mod.rs
@@ -1,13 +1,17 @@
+pub mod hit;
 pub mod join_table;
 pub mod leave_seat;
 pub mod leave_table;
 pub mod place_bet;
+pub mod stand;
 pub mod take_seat;
 
+pub use hit::Hit;
 pub use join_table::JoinTable;
 pub use leave_seat::LeaveSeat;
 pub use leave_table::LeaveTable;
 pub use place_bet::PlaceBet;
+pub use stand::Stand;
 pub use take_seat::TakeSeat;
 
 use crate::domain::engine::command::{CommandHandler, CommandId};
@@ -26,10 +30,12 @@ pub struct PlayerCommand {
 
 #[derive(Debug, Clone)]
 pub enum PlayerAction {
+    Hit(Hit),
     JoinTable(JoinTable),
     LeaveSeat(LeaveSeat),
     LeaveTable(LeaveTable),
     PlaceBet(PlaceBet),
+    Stand(Stand),
     TakeSeat(TakeSeat),
 }
 
@@ -40,10 +46,12 @@ impl CommandHandler for PlayerAction {
         settings: &TableSettings,
     ) -> Result<Vec<EventPayload>, CommandError> {
         match self {
+            Self::Hit(h) => h.handle(state, settings),
             Self::JoinTable(h) => h.handle(state, settings),
             Self::LeaveSeat(h) => h.handle(state, settings),
             Self::LeaveTable(h) => h.handle(state, settings),
             Self::PlaceBet(h) => h.handle(state, settings),
+            Self::Stand(h) => h.handle(state, settings),
             Self::TakeSeat(h) => h.handle(state, settings),
         }
     }

--- a/core/src/domain/engine/command/player/stand.rs
+++ b/core/src/domain/engine/command/player/stand.rs
@@ -1,9 +1,11 @@
-use crate::domain::engine::command::CommandHandler;
-use crate::domain::engine::error::CommandError;
-use crate::domain::engine::event::payload::EventPayload;
-use crate::domain::engine::game_state::GameState;
-use crate::domain::player::PlayerId;
-use crate::domain::table::TableSettings;
+use crate::domain::{
+    engine::{
+        action::PlayerDecision, command::CommandHandler, error::CommandError,
+        event::payload::EventPayload, game_state::GameState, phase::Phase,
+    },
+    player::PlayerId,
+    table::TableSettings,
+};
 
 #[derive(Debug, Clone)]
 pub struct Stand {
@@ -13,9 +15,123 @@ pub struct Stand {
 impl CommandHandler for Stand {
     fn handle(
         &self,
-        _state: &GameState,
+        state: &GameState,
         _settings: &TableSettings,
     ) -> Result<Vec<EventPayload>, CommandError> {
-        todo!("stand handler")
+        match &state.phase {
+            Phase::PlayerTurn(id) if *id == self.player_id => {}
+            _ => return Err(CommandError::NotPlayersTurn),
+        }
+        Ok(vec![
+            EventPayload::PlayerDecisionTaken {
+                player: self.player_id,
+                action: PlayerDecision::Stand,
+            },
+            EventPayload::PhaseChanged {
+                from: Phase::PlayerTurn(self.player_id),
+                to: state.next_player_after(self.player_id),
+            },
+        ])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        dealer::DealerId,
+        engine::{
+            command::{
+                player::{PlayerAction, PlayerCommand},
+                CommandId, GameCommand,
+            },
+            game_id::GameId,
+            game_state::GameState,
+            phase::Phase,
+            GameEngine,
+        },
+        player::PlayerId,
+        table::TableSettings,
+        Card, DeckId, Rank, Suit,
+    };
+
+    fn settings() -> TableSettings {
+        TableSettings {
+            min_bet: 10,
+            max_bet: 500,
+            max_players: 5,
+            max_observers: 10,
+        }
+    }
+
+    fn card(rank: Rank) -> Card {
+        Card {
+            deck_id: DeckId::One,
+            rank,
+            suit: Suit::Spades,
+        }
+    }
+
+    fn stand_cmd(pid: PlayerId) -> GameCommand {
+        GameCommand::Player(PlayerCommand {
+            game_id: GameId::new(),
+            command_id: CommandId(0),
+            action: PlayerAction::Stand(Stand { player_id: pid }),
+        })
+    }
+
+    fn state_in_player_turn(pid: PlayerId) -> GameState {
+        let shoe = vec![card(Rank::King); 30];
+        let mut state =
+            GameState::new_with_balance(GameId::new(), shoe, vec![(pid, 1000)], DealerId::new());
+        state.players[0].bet = Some(100);
+        state.phase = Phase::PlayerTurn(pid);
+        state
+    }
+
+    #[test]
+    fn stand_single_player_goes_to_dealer() {
+        let pid = PlayerId::new();
+        let state = state_in_player_turn(pid);
+        let events = GameEngine::handle(&state, &settings(), &stand_cmd(pid)).unwrap();
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            events[1],
+            EventPayload::PhaseChanged {
+                to: Phase::DealerTurn,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn stand_advances_to_next_player() {
+        let p1 = PlayerId::new();
+        let p2 = PlayerId::new();
+        let shoe = vec![card(Rank::King); 30];
+        let mut state = GameState::new_with_balance(
+            GameId::new(),
+            shoe,
+            vec![(p1, 1000), (p2, 1000)],
+            DealerId::new(),
+        );
+        state.players[0].bet = Some(100);
+        state.players[1].bet = Some(100);
+        state.phase = Phase::PlayerTurn(p1);
+        let events = GameEngine::handle(&state, &settings(), &stand_cmd(p1)).unwrap();
+        assert!(
+            matches!(events[1], EventPayload::PhaseChanged { to: Phase::PlayerTurn(id), .. } if id == p2)
+        );
+    }
+
+    #[test]
+    fn stand_wrong_turn() {
+        let pid = PlayerId::new();
+        let other = PlayerId::new();
+        let state = state_in_player_turn(pid);
+        assert!(matches!(
+            GameEngine::handle(&state, &settings(), &stand_cmd(other)),
+            Err(CommandError::NotPlayersTurn)
+        ));
     }
 }

--- a/core/src/domain/engine/command/system/mod.rs
+++ b/core/src/domain/engine/command/system/mod.rs
@@ -1,28 +1,16 @@
-use crate::domain::engine::command::{CommandHandler, CommandId};
+pub mod player_timeout;
+
+pub use player_timeout::PlayerTimeout;
+
+use crate::domain::engine::command::CommandHandler;
 use crate::domain::engine::error::CommandError;
 use crate::domain::engine::event::payload::EventPayload;
-use crate::domain::engine::game_id::GameId;
 use crate::domain::engine::game_state::GameState;
 use crate::domain::table::TableSettings;
 
 #[derive(Debug, Clone)]
-pub struct SystemCommand {
-    pub game_id: GameId,
-    pub command_id: CommandId,
-    pub action: SystemAction,
-}
-
-#[derive(Debug, Clone)]
-pub enum SystemAction {}
-
-impl CommandHandler for SystemAction {
-    fn handle(
-        &self,
-        _state: &GameState,
-        _settings: &TableSettings,
-    ) -> Result<Vec<EventPayload>, CommandError> {
-        match *self {}
-    }
+pub enum SystemCommand {
+    PlayerTimeout(PlayerTimeout),
 }
 
 impl CommandHandler for SystemCommand {
@@ -31,6 +19,8 @@ impl CommandHandler for SystemCommand {
         state: &GameState,
         settings: &TableSettings,
     ) -> Result<Vec<EventPayload>, CommandError> {
-        self.action.handle(state, settings)
+        match self {
+            Self::PlayerTimeout(h) => h.handle(state, settings),
+        }
     }
 }

--- a/core/src/domain/engine/command/system/player_timeout.rs
+++ b/core/src/domain/engine/command/system/player_timeout.rs
@@ -1,9 +1,13 @@
-use crate::domain::engine::command::CommandHandler;
-use crate::domain::engine::error::CommandError;
-use crate::domain::engine::event::payload::EventPayload;
-use crate::domain::engine::game_state::GameState;
-use crate::domain::player::PlayerId;
-use crate::domain::table::TableSettings;
+use crate::domain::{
+    engine::{
+        command::{player::Stand, CommandHandler},
+        error::CommandError,
+        event::payload::EventPayload,
+        game_state::GameState,
+    },
+    player::PlayerId,
+    table::TableSettings,
+};
 
 #[derive(Debug, Clone)]
 pub struct PlayerTimeout {
@@ -13,9 +17,70 @@ pub struct PlayerTimeout {
 impl CommandHandler for PlayerTimeout {
     fn handle(
         &self,
-        _state: &GameState,
-        _settings: &TableSettings,
+        state: &GameState,
+        settings: &TableSettings,
     ) -> Result<Vec<EventPayload>, CommandError> {
-        todo!("player timeout handler")
+        Stand {
+            player_id: self.player_id,
+        }
+        .handle(state, settings)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        dealer::DealerId,
+        engine::{
+            command::{system::SystemCommand, GameCommand},
+            game_id::GameId,
+            game_state::GameState,
+            phase::Phase,
+            GameEngine,
+        },
+        player::PlayerId,
+        table::TableSettings,
+        Card, DeckId, Rank, Suit,
+    };
+
+    fn settings() -> TableSettings {
+        TableSettings {
+            min_bet: 10,
+            max_bet: 500,
+            max_players: 5,
+            max_observers: 10,
+        }
+    }
+
+    fn card(rank: Rank) -> Card {
+        Card {
+            deck_id: DeckId::One,
+            rank,
+            suit: Suit::Spades,
+        }
+    }
+
+    #[test]
+    fn timeout_acts_as_stand() {
+        let pid = PlayerId::new();
+        let shoe = vec![card(Rank::King); 30];
+        let mut state =
+            GameState::new_with_balance(GameId::new(), shoe, vec![(pid, 1000)], DealerId::new());
+        state.players[0].bet = Some(100);
+        state.phase = Phase::PlayerTurn(pid);
+
+        let cmd = GameCommand::System(SystemCommand::PlayerTimeout(PlayerTimeout {
+            player_id: pid,
+        }));
+        let events = GameEngine::handle(&state, &settings(), &cmd).unwrap();
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            events[1],
+            EventPayload::PhaseChanged {
+                to: Phase::DealerTurn,
+                ..
+            }
+        ));
     }
 }


### PR DESCRIPTION
Fourth of 11 stacked PRs. Targets `pr/03-core-betting`.

Adds dealing and player turn command handlers:

- **DealInitialCards** (dealer) — deals 2 cards to each seated player and 2 to dealer (one face-down hole card); transitions to `InitialDealing` → `PlayerTurn`
- **Hit** (player) — deals one more card; checks bust, advances turn if bust
- **Stand** (player) — advances turn to next player or `DealerTurn`
- **PlayerTimeout** (system) — treated as Stand; player forfeits their turn

Also restructures `SystemCommand` from a struct wrapper to a flat enum (matching PoC design — system commands carry no `game_id`/`command_id`).

79 unit tests pass.