### PR TITLE
feat(core): dealer turn and round settlement

### DIFF
--- a/core/src/domain/engine/command/dealer/mod.rs
+++ b/core/src/domain/engine/command/dealer/mod.rs
@@ -1,8 +1,12 @@
 pub mod deal_initial_cards;
 pub mod open_betting;
+pub mod play_hand;
+pub mod settle_round;
 
 pub use deal_initial_cards::DealInitialCards;
 pub use open_betting::OpenBetting;
+pub use play_hand::PlayHand;
+pub use settle_round::SettleRound;
 
 use crate::domain::engine::command::{CommandHandler, CommandId};
 use crate::domain::engine::error::CommandError;
@@ -22,6 +26,8 @@ pub struct DealerCommand {
 pub enum DealerAction {
     DealInitialCards(DealInitialCards),
     OpenBetting(OpenBetting),
+    PlayHand(PlayHand),
+    SettleRound(SettleRound),
 }
 
 impl CommandHandler for DealerAction {
@@ -33,6 +39,8 @@ impl CommandHandler for DealerAction {
         match self {
             Self::DealInitialCards(h) => h.handle(state, settings),
             Self::OpenBetting(h) => h.handle(state, settings),
+            Self::PlayHand(h) => h.handle(state, settings),
+            Self::SettleRound(h) => h.handle(state, settings),
         }
     }
 }

--- a/core/src/domain/engine/command/dealer/play_hand.rs
+++ b/core/src/domain/engine/command/dealer/play_hand.rs
@@ -1,8 +1,10 @@
-use crate::domain::engine::command::CommandHandler;
-use crate::domain::engine::error::CommandError;
-use crate::domain::engine::event::payload::EventPayload;
-use crate::domain::engine::game_state::GameState;
-use crate::domain::table::TableSettings;
+use crate::domain::{
+    engine::{
+        command::CommandHandler, error::CommandError, event::payload::EventPayload,
+        game_state::GameState, phase::Phase,
+    },
+    table::TableSettings,
+};
 
 #[derive(Debug, Clone)]
 pub struct PlayHand;
@@ -10,9 +12,167 @@ pub struct PlayHand;
 impl CommandHandler for PlayHand {
     fn handle(
         &self,
-        _state: &GameState,
+        state: &GameState,
         _settings: &TableSettings,
     ) -> Result<Vec<EventPayload>, CommandError> {
-        todo!("play hand handler")
+        if !matches!(state.phase, Phase::DealerTurn) {
+            return Err(CommandError::WrongPhase {
+                actual: state.phase.clone(),
+            });
+        }
+
+        let mut events = vec![];
+
+        // Reveal the hole card to clients before the dealer plays.
+        if state.dealer.hand.cards.len() >= 2 {
+            events.push(EventPayload::DealerHoleCardRevealed {
+                dealer: state.dealer.dealer_id,
+                card: state.dealer.hand.cards[1],
+            });
+        }
+
+        let mut hand = state.dealer.hand.clone();
+        let mut dealt = state.dealt;
+
+        loop {
+            let score = hand.value().best_value();
+            if score >= 17 {
+                break;
+            }
+            let card = *state.shoe.get(dealt).ok_or(CommandError::ShoeEmpty)?;
+            events.push(EventPayload::DealerCardDealt {
+                dealer: state.dealer.dealer_id,
+                card,
+            });
+            hand.add_card(card);
+            dealt += 1;
+        }
+
+        if hand.value().is_bust() {
+            events.push(EventPayload::DealerBust {
+                dealer: state.dealer.dealer_id,
+            });
+        }
+        events.push(EventPayload::PhaseChanged {
+            from: Phase::DealerTurn,
+            to: Phase::Payouts,
+        });
+
+        Ok(events)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        dealer::DealerId,
+        engine::{
+            command::{CommandId, DealerCommand, GameCommand},
+            game_id::GameId,
+            game_state::GameState,
+            GameEngine,
+        },
+        table::TableSettings,
+        Card, DeckId, Rank, Suit,
+    };
+
+    fn settings() -> TableSettings {
+        TableSettings {
+            min_bet: 10,
+            max_bet: 500,
+            max_players: 5,
+            max_observers: 10,
+        }
+    }
+
+    fn card(rank: Rank) -> Card {
+        Card {
+            deck_id: DeckId::One,
+            rank,
+            suit: Suit::Spades,
+        }
+    }
+
+    fn cmd() -> GameCommand {
+        use crate::domain::engine::command::DealerAction;
+        GameCommand::Dealer(DealerCommand {
+            game_id: GameId::new(),
+            command_id: CommandId(0),
+            action: DealerAction::PlayHand(PlayHand),
+        })
+    }
+
+    fn state_with_dealer_hand(dealer_cards: Vec<Rank>, shoe_cards: Vec<Rank>) -> GameState {
+        let shoe: Vec<Card> = shoe_cards.iter().map(|&r| card(r)).collect();
+        let mut state = GameState::new(GameId::new(), shoe, vec![], DealerId::new());
+        state.phase = Phase::DealerTurn;
+        for r in dealer_cards {
+            state.dealer.hand.add_card(card(r));
+        }
+        state
+    }
+
+    #[test]
+    fn dealer_stands_at_17() {
+        // Dealer has King(10)+Seven(7)=17, no more cards needed
+        let state = state_with_dealer_hand(vec![Rank::King, Rank::Seven], vec![Rank::Two; 10]);
+        let events = GameEngine::handle(&state, &settings(), &cmd()).unwrap();
+        // DealerHoleCardRevealed + PhaseChanged
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            events[0],
+            EventPayload::DealerHoleCardRevealed { .. }
+        ));
+        assert!(matches!(
+            events[1],
+            EventPayload::PhaseChanged {
+                to: Phase::Payouts,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn dealer_draws_to_17() {
+        // Dealer has King(10)+Five(5)=15, draws Two(2) -> 17
+        let state = state_with_dealer_hand(vec![Rank::King, Rank::Five], vec![Rank::Two]);
+        let events = GameEngine::handle(&state, &settings(), &cmd()).unwrap();
+        // DealerHoleCardRevealed + DealerCardDealt + PhaseChanged
+        assert_eq!(events.len(), 3);
+        assert!(matches!(
+            events[0],
+            EventPayload::DealerHoleCardRevealed { .. }
+        ));
+        assert!(matches!(events[1], EventPayload::DealerCardDealt { .. }));
+    }
+
+    #[test]
+    fn dealer_busts() {
+        // Dealer has King(10)+Six(6)=16, draws King(10) -> 26 bust
+        let state = state_with_dealer_hand(vec![Rank::King, Rank::Six], vec![Rank::King]);
+        let events = GameEngine::handle(&state, &settings(), &cmd()).unwrap();
+        // DealerHoleCardRevealed + DealerCardDealt + DealerBust + PhaseChanged
+        assert_eq!(events.len(), 4);
+        assert!(matches!(
+            events[0],
+            EventPayload::DealerHoleCardRevealed { .. }
+        ));
+        assert!(matches!(events[2], EventPayload::DealerBust { .. }));
+    }
+
+    #[test]
+    fn wrong_phase_errors() {
+        let state = GameState::new(
+            GameId::new(),
+            crate::domain::Shoe::shuffled(),
+            vec![],
+            DealerId::new(),
+        );
+        // default phase is WaitingForBets
+        assert!(matches!(
+            GameEngine::handle(&state, &settings(), &cmd()),
+            Err(CommandError::WrongPhase { .. })
+        ));
     }
 }

--- a/core/src/domain/engine/command/dealer/settle_round.rs
+++ b/core/src/domain/engine/command/dealer/settle_round.rs
@@ -1,18 +1,297 @@
-use crate::domain::engine::command::CommandHandler;
-use crate::domain::engine::error::CommandError;
-use crate::domain::engine::event::payload::EventPayload;
-use crate::domain::engine::game_state::GameState;
-use crate::domain::table::TableSettings;
+use crate::domain::{
+    engine::{
+        command::CommandHandler,
+        error::CommandError,
+        event::{
+            outcome::{GameResult, Payout, PayoutMultiplier, PlayerOutcome, PlayerResult},
+            payload::EventPayload,
+        },
+        game_state::GameState,
+        phase::Phase,
+    },
+    hand::Hand,
+    player::PlayerState,
+    table::TableSettings,
+};
 
 #[derive(Debug, Clone)]
 pub struct SettleRound;
 
+fn is_natural_blackjack(hand: &Hand) -> bool {
+    hand.cards.len() == 2 && hand.value().best_value() == 21
+}
+
+fn settle_player(
+    player: &PlayerState,
+    dealer_hand: &Hand,
+    dealer_busted: bool,
+) -> (PlayerOutcome, PayoutMultiplier) {
+    if player.hand.value().is_bust() {
+        return (PlayerOutcome::Bust, PayoutMultiplier::Loss);
+    }
+    let player_bj = is_natural_blackjack(&player.hand);
+    let dealer_bj = is_natural_blackjack(dealer_hand);
+
+    if player_bj && dealer_bj {
+        return (PlayerOutcome::Push, PayoutMultiplier::Push);
+    }
+    if player_bj {
+        return (PlayerOutcome::Blackjack, PayoutMultiplier::Blackjack);
+    }
+    if dealer_bj {
+        return (PlayerOutcome::Lost, PayoutMultiplier::Loss);
+    }
+    if dealer_busted {
+        return (PlayerOutcome::Won, PayoutMultiplier::Win);
+    }
+    let pv = player.hand.value().best_value();
+    let dv = dealer_hand.value().best_value();
+    if pv > dv {
+        (PlayerOutcome::Won, PayoutMultiplier::Win)
+    } else if pv == dv {
+        (PlayerOutcome::Push, PayoutMultiplier::Push)
+    } else {
+        (PlayerOutcome::Lost, PayoutMultiplier::Loss)
+    }
+}
+
 impl CommandHandler for SettleRound {
     fn handle(
         &self,
-        _state: &GameState,
+        state: &GameState,
         _settings: &TableSettings,
     ) -> Result<Vec<EventPayload>, CommandError> {
-        todo!("settle round handler")
+        if !matches!(state.phase, Phase::Payouts) {
+            return Err(CommandError::WrongPhase {
+                actual: state.phase.clone(),
+            });
+        }
+        let dealer_busted = state.dealer.hand.value().is_bust();
+        let player_results: Vec<PlayerResult> = state
+            .players
+            .iter()
+            .filter(|p| p.bet.is_some())
+            .map(|p| {
+                let (outcome, multiplier) = settle_player(p, &state.dealer.hand, dealer_busted);
+                let bet = p.bet.unwrap();
+                PlayerResult {
+                    player: p.player_id,
+                    outcome,
+                    payout: Payout::new(bet, multiplier),
+                }
+            })
+            .collect();
+
+        Ok(vec![
+            EventPayload::GameFinished {
+                result: GameResult {
+                    player_results,
+                    dealer_busted,
+                },
+            },
+            EventPayload::PhaseChanged {
+                from: Phase::Payouts,
+                to: Phase::Finished,
+            },
+        ])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        dealer::DealerId,
+        engine::{
+            command::{
+                dealer::{DealerAction, DealerCommand},
+                CommandId, GameCommand,
+            },
+            event::outcome::PlayerOutcome,
+            game_id::GameId,
+            game_state::GameState,
+            GameEngine,
+        },
+        player::PlayerId,
+        table::TableSettings,
+        Card, DeckId, Rank, Suit,
+    };
+
+    fn settings() -> TableSettings {
+        TableSettings {
+            min_bet: 10,
+            max_bet: 500,
+            max_players: 5,
+            max_observers: 10,
+        }
+    }
+
+    fn card(rank: Rank) -> Card {
+        Card {
+            deck_id: DeckId::One,
+            rank,
+            suit: Suit::Spades,
+        }
+    }
+
+    fn cmd() -> GameCommand {
+        GameCommand::Dealer(DealerCommand {
+            game_id: GameId::new(),
+            command_id: CommandId(0),
+            action: DealerAction::SettleRound(SettleRound),
+        })
+    }
+
+    fn state_at_payouts(
+        player_ranks: Vec<Rank>,
+        dealer_ranks: Vec<Rank>,
+        bet: u32,
+    ) -> (GameState, PlayerId) {
+        let pid = PlayerId::new();
+        let shoe = crate::domain::Shoe::shuffled();
+        let mut state =
+            GameState::new_with_balance(GameId::new(), shoe, vec![(pid, 1000)], DealerId::new());
+        state.phase = Phase::Payouts;
+        state.players[0].bet = Some(bet);
+        for r in player_ranks {
+            state.players[0].hand.add_card(card(r));
+        }
+        for r in dealer_ranks {
+            state.dealer.hand.add_card(card(r));
+        }
+        (state, pid)
+    }
+
+    fn outcome_for(events: &[EventPayload], pid: PlayerId) -> PlayerOutcome {
+        for e in events {
+            if let EventPayload::GameFinished { result } = e {
+                for r in &result.player_results {
+                    if r.player == pid {
+                        return r.outcome.clone();
+                    }
+                }
+            }
+        }
+        panic!("no result found")
+    }
+
+    #[test]
+    fn player_wins() {
+        let (state, pid) = state_at_payouts(
+            vec![Rank::King, Rank::Nine],
+            vec![Rank::King, Rank::Seven],
+            100,
+        );
+        let events = GameEngine::handle(&state, &settings(), &cmd()).unwrap();
+        assert_eq!(outcome_for(&events, pid), PlayerOutcome::Won);
+    }
+
+    #[test]
+    fn player_loses() {
+        let (state, pid) = state_at_payouts(
+            vec![Rank::King, Rank::Seven],
+            vec![Rank::King, Rank::Nine],
+            100,
+        );
+        let events = GameEngine::handle(&state, &settings(), &cmd()).unwrap();
+        assert_eq!(outcome_for(&events, pid), PlayerOutcome::Lost);
+    }
+
+    #[test]
+    fn push() {
+        let (state, pid) = state_at_payouts(
+            vec![Rank::King, Rank::Eight],
+            vec![Rank::King, Rank::Eight],
+            100,
+        );
+        let events = GameEngine::handle(&state, &settings(), &cmd()).unwrap();
+        assert_eq!(outcome_for(&events, pid), PlayerOutcome::Push);
+    }
+
+    #[test]
+    fn player_blackjack() {
+        let (state, pid) = state_at_payouts(
+            vec![Rank::Ace, Rank::King],
+            vec![Rank::King, Rank::Eight],
+            100,
+        );
+        let events = GameEngine::handle(&state, &settings(), &cmd()).unwrap();
+        assert_eq!(outcome_for(&events, pid), PlayerOutcome::Blackjack);
+    }
+
+    #[test]
+    fn both_blackjack_push() {
+        let (state, pid) = state_at_payouts(
+            vec![Rank::Ace, Rank::King],
+            vec![Rank::Ace, Rank::King],
+            100,
+        );
+        let events = GameEngine::handle(&state, &settings(), &cmd()).unwrap();
+        assert_eq!(outcome_for(&events, pid), PlayerOutcome::Push);
+    }
+
+    #[test]
+    fn dealer_busts_player_wins() {
+        let (state, pid) = state_at_payouts(
+            vec![Rank::King, Rank::Eight],
+            vec![Rank::King, Rank::Queen, Rank::Five],
+            100,
+        );
+        let events = GameEngine::handle(&state, &settings(), &cmd()).unwrap();
+        assert_eq!(outcome_for(&events, pid), PlayerOutcome::Won);
+    }
+
+    #[test]
+    fn player_busts_loses() {
+        let (state, pid) = state_at_payouts(
+            vec![Rank::King, Rank::Queen, Rank::Five],
+            vec![Rank::King, Rank::Eight],
+            100,
+        );
+        let events = GameEngine::handle(&state, &settings(), &cmd()).unwrap();
+        assert_eq!(outcome_for(&events, pid), PlayerOutcome::Bust);
+    }
+
+    #[test]
+    fn wrong_phase() {
+        let state = GameState::new(
+            GameId::new(),
+            crate::domain::Shoe::shuffled(),
+            vec![],
+            DealerId::new(),
+        );
+        assert!(matches!(
+            GameEngine::handle(&state, &settings(), &cmd()),
+            Err(CommandError::WrongPhase { .. })
+        ));
+    }
+
+    #[test]
+    fn dealer_blackjack_beats_player_21() {
+        let (state, pid) = state_at_payouts(
+            vec![Rank::King, Rank::Seven, Rank::Four], // non-natural 21
+            vec![Rank::Ace, Rank::King],               // dealer blackjack
+            100,
+        );
+        let events = GameEngine::handle(&state, &settings(), &cmd()).unwrap();
+        assert_eq!(outcome_for(&events, pid), PlayerOutcome::Lost);
+    }
+
+    #[test]
+    fn payout_total_on_win() {
+        let (state, pid) = state_at_payouts(
+            vec![Rank::King, Rank::Nine],
+            vec![Rank::King, Rank::Seven],
+            100,
+        );
+        let events = GameEngine::handle(&state, &settings(), &cmd()).unwrap();
+        if let EventPayload::GameFinished { result } = &events[0] {
+            let r = result
+                .player_results
+                .iter()
+                .find(|r| r.player == pid)
+                .unwrap();
+            assert_eq!(r.payout.total(), 200);
+        }
     }
 }


### PR DESCRIPTION
Fifth of 11 stacked PRs. Targets `pr/04-core-dealing`.

Completes the full core game loop with two dealer commands:

- **PlayHand** — reveals dealer hole card, hits until ≥ 17, emits bust if > 21; transitions to `Payouts` phase
- **SettleRound** — computes outcomes (Blackjack 3:2, push, win/loss, dealer bust) and emits `GameFinished` with balance updates

93 unit tests pass.