### PR TITLE
feat(core): GameStateSnapshot and GameEventDto

### DIFF
--- a/core/src/domain/engine/command/dealer/deal_initial_cards.rs
+++ b/core/src/domain/engine/command/dealer/deal_initial_cards.rs
@@ -21,7 +21,7 @@ impl CommandHandler for DealInitialCards {
             });
         }
         let mut bettors: Vec<_> = state.players.iter().filter(|p| p.bet.is_some()).collect();
-        bettors.sort_by_key(|p| p.seat);
+        bettors.sort_unstable_by_key(|p| p.seat);
         if bettors.is_empty() {
             return Err(CommandError::NoBettors);
         }

--- a/core/src/domain/engine/command/dealer/deal_initial_cards.rs
+++ b/core/src/domain/engine/command/dealer/deal_initial_cards.rs
@@ -20,7 +20,8 @@ impl CommandHandler for DealInitialCards {
                 actual: state.phase.clone(),
             });
         }
-        let bettors: Vec<_> = state.players.iter().filter(|p| p.bet.is_some()).collect();
+        let mut bettors: Vec<_> = state.players.iter().filter(|p| p.bet.is_some()).collect();
+        bettors.sort_by_key(|p| p.seat);
         if bettors.is_empty() {
             return Err(CommandError::NoBettors);
         }

--- a/core/src/domain/engine/command/dealer/open_betting.rs
+++ b/core/src/domain/engine/command/dealer/open_betting.rs
@@ -4,6 +4,7 @@ use crate::domain::{
         game_state::GameState, phase::Phase,
     },
     table::TableSettings,
+    Seat,
 };
 
 #[derive(Debug, Clone)]
@@ -19,9 +20,22 @@ impl CommandHandler for OpenBetting {
             Phase::WaitingForBets => Ok(vec![]),
             Phase::Finished => {
                 let mut events = vec![];
-                let seats_available = settings.max_players.saturating_sub(state.players.len());
-                for &pid in state.waiting.iter().take(seats_available) {
-                    events.push(EventPayload::PlayerJoined { player: pid });
+                let mut occupied: std::collections::BTreeSet<Seat> =
+                    state.players.iter().map(|p| p.seat).collect();
+                let available_seats = settings.max_players.saturating_sub(state.players.len());
+                for &(pid, desired) in state.waiting.iter().take(available_seats) {
+                    let seat = if !occupied.contains(&desired) {
+                        desired
+                    } else {
+                        Seat::ALL
+                            .iter()
+                            .take(settings.max_players)
+                            .copied()
+                            .find(|s| !occupied.contains(s))
+                            .expect("seat available — available_seats guard ensures capacity")
+                    };
+                    occupied.insert(seat);
+                    events.push(EventPayload::PlayerJoined { player: pid, seat });
                 }
                 events.push(EventPayload::PhaseChanged {
                     from: Phase::Finished,
@@ -51,7 +65,7 @@ mod tests {
         },
         player::PlayerId,
         table::TableSettings,
-        Shoe,
+        Seat, Shoe,
     };
 
     fn settings() -> TableSettings {
@@ -99,13 +113,13 @@ mod tests {
         state.phase = Phase::Finished;
         let pid1 = PlayerId::new();
         let pid2 = PlayerId::new();
-        state.waiting.push(pid1);
-        state.waiting.push(pid2);
+        state.waiting.push((pid1, Seat::One));
+        state.waiting.push((pid2, Seat::Two));
         let events = GameEngine::handle(&state, &settings(), &cmd()).unwrap();
         // Two PlayerJoined + one PhaseChanged
         assert_eq!(events.len(), 3);
-        assert!(matches!(events[0], EventPayload::PlayerJoined { player } if player == pid1));
-        assert!(matches!(events[1], EventPayload::PlayerJoined { player } if player == pid2));
+        assert!(matches!(events[0], EventPayload::PlayerJoined { player, seat: Seat::One } if player == pid1));
+        assert!(matches!(events[1], EventPayload::PlayerJoined { player, seat: Seat::Two } if player == pid2));
         assert!(matches!(
             &events[2],
             EventPayload::PhaseChanged {
@@ -119,15 +133,15 @@ mod tests {
     fn open_betting_respects_max_players() {
         let mut state = GameState::new(GameId::new(), Shoe::shuffled(), vec![], DealerId::new());
         state.phase = Phase::Finished;
-        // Fill one seat
+        // Fill seat One
         state
             .players
-            .push(crate::domain::player::PlayerState::new(PlayerId::new()));
+            .push(crate::domain::player::PlayerState::at_seat(PlayerId::new(), Seat::One));
         // Two waiting but max_players is 2 so only one slot left
         let pid1 = PlayerId::new();
         let pid2 = PlayerId::new();
-        state.waiting.push(pid1);
-        state.waiting.push(pid2);
+        state.waiting.push((pid1, Seat::Two));
+        state.waiting.push((pid2, Seat::Three));
 
         let s = TableSettings {
             min_bet: 10,
@@ -138,7 +152,7 @@ mod tests {
         let events = GameEngine::handle(&state, &s, &cmd()).unwrap();
         // One PlayerJoined + PhaseChanged
         assert_eq!(events.len(), 2);
-        assert!(matches!(events[0], EventPayload::PlayerJoined { player } if player == pid1));
+        assert!(matches!(events[0], EventPayload::PlayerJoined { player, .. } if player == pid1));
     }
 
     #[test]

--- a/core/src/domain/engine/command/dealer/open_betting.rs
+++ b/core/src/domain/engine/command/dealer/open_betting.rs
@@ -118,8 +118,12 @@ mod tests {
         let events = GameEngine::handle(&state, &settings(), &cmd()).unwrap();
         // Two PlayerJoined + one PhaseChanged
         assert_eq!(events.len(), 3);
-        assert!(matches!(events[0], EventPayload::PlayerJoined { player, seat: Seat::One } if player == pid1));
-        assert!(matches!(events[1], EventPayload::PlayerJoined { player, seat: Seat::Two } if player == pid2));
+        assert!(
+            matches!(events[0], EventPayload::PlayerJoined { player, seat: Seat::One } if player == pid1)
+        );
+        assert!(
+            matches!(events[1], EventPayload::PlayerJoined { player, seat: Seat::Two } if player == pid2)
+        );
         assert!(matches!(
             &events[2],
             EventPayload::PhaseChanged {
@@ -136,7 +140,10 @@ mod tests {
         // Fill seat One
         state
             .players
-            .push(crate::domain::player::PlayerState::at_seat(PlayerId::new(), Seat::One));
+            .push(crate::domain::player::PlayerState::at_seat(
+                PlayerId::new(),
+                Seat::One,
+            ));
         // Two waiting but max_players is 2 so only one slot left
         let pid1 = PlayerId::new();
         let pid2 = PlayerId::new();

--- a/core/src/domain/engine/command/player/join_table.rs
+++ b/core/src/domain/engine/command/player/join_table.rs
@@ -21,7 +21,7 @@ impl CommandHandler for JoinTable {
         // Idempotent: already anywhere at this table
         if state.players.iter().any(|p| p.player_id == self.player_id)
             || state.observers.contains(&self.player_id)
-            || state.waiting.contains(&self.player_id)
+            || state.waiting.iter().any(|(p, _)| *p == self.player_id)
         {
             return Ok(vec![]);
         }
@@ -120,7 +120,7 @@ mod tests {
     fn join_idempotent_in_waiting_list() {
         let mut state = empty_state();
         let pid = PlayerId::new();
-        state.waiting.push(pid);
+        state.waiting.push((pid, crate::domain::Seat::One));
         let events = GameEngine::handle(&state, &settings(5), &cmd(pid)).unwrap();
         assert!(events.is_empty());
     }

--- a/core/src/domain/engine/command/player/leave_seat.rs
+++ b/core/src/domain/engine/command/player/leave_seat.rs
@@ -39,7 +39,7 @@ impl CommandHandler for LeaveSeat {
             return Ok(events);
         }
 
-        if state.waiting.contains(&self.player_id) {
+        if state.waiting.iter().any(|(p, _)| *p == self.player_id) {
             return Ok(vec![
                 EventPayload::PlayerRemovedFromWaitingList {
                     player: self.player_id,
@@ -76,7 +76,7 @@ mod tests {
         },
         player::PlayerId,
         table::TableSettings,
-        Shoe,
+        Seat, Shoe,
     };
 
     fn settings() -> TableSettings {
@@ -105,7 +105,7 @@ mod tests {
             &GameCommand::Player(PlayerCommand {
                 game_id: GameId::new(),
                 command_id: CommandId(0),
-                action: PlayerAction::TakeSeat(TakeSeat { player_id: pid }),
+                action: PlayerAction::TakeSeat(TakeSeat { player_id: pid, seat: Seat::One }),
             }),
         )
         .unwrap();
@@ -147,7 +147,7 @@ mod tests {
     fn waiting_list_player_returns_to_observer() {
         let pid = PlayerId::new();
         let mut state = GameState::new(GameId::new(), Shoe::shuffled(), vec![], DealerId::new());
-        state.waiting.push(pid);
+        state.waiting.push((pid, Seat::One));
         let events = GameEngine::handle(&state, &settings(), &leave_seat_cmd(pid)).unwrap();
         assert!(
             matches!(events[0], EventPayload::PlayerRemovedFromWaitingList { player } if player == pid)

--- a/core/src/domain/engine/command/player/leave_seat.rs
+++ b/core/src/domain/engine/command/player/leave_seat.rs
@@ -105,7 +105,10 @@ mod tests {
             &GameCommand::Player(PlayerCommand {
                 game_id: GameId::new(),
                 command_id: CommandId(0),
-                action: PlayerAction::TakeSeat(TakeSeat { player_id: pid, seat: Seat::One }),
+                action: PlayerAction::TakeSeat(TakeSeat {
+                    player_id: pid,
+                    seat: Seat::One,
+                }),
             }),
         )
         .unwrap();

--- a/core/src/domain/engine/command/player/leave_table.rs
+++ b/core/src/domain/engine/command/player/leave_table.rs
@@ -92,7 +92,10 @@ mod tests {
             &GameCommand::Player(PlayerCommand {
                 game_id: GameId::new(),
                 command_id: CommandId(0),
-                action: PlayerAction::TakeSeat(TakeSeat { player_id: pid, seat: Seat::One }),
+                action: PlayerAction::TakeSeat(TakeSeat {
+                    player_id: pid,
+                    seat: Seat::One,
+                }),
             }),
         )
         .unwrap();

--- a/core/src/domain/engine/command/player/leave_table.rs
+++ b/core/src/domain/engine/command/player/leave_table.rs
@@ -44,7 +44,7 @@ impl CommandHandler for LeaveTable {
             }]);
         }
 
-        if state.waiting.contains(&self.player_id) {
+        if state.waiting.iter().any(|(p, _)| *p == self.player_id) {
             return Ok(vec![EventPayload::PlayerRemovedFromWaitingList {
                 player: self.player_id,
             }]);
@@ -69,7 +69,7 @@ mod tests {
             GameEngine,
         },
         table::TableSettings,
-        Shoe,
+        Seat, Shoe,
     };
 
     fn settings() -> TableSettings {
@@ -92,7 +92,7 @@ mod tests {
             &GameCommand::Player(PlayerCommand {
                 game_id: GameId::new(),
                 command_id: CommandId(0),
-                action: PlayerAction::TakeSeat(TakeSeat { player_id: pid }),
+                action: PlayerAction::TakeSeat(TakeSeat { player_id: pid, seat: Seat::One }),
             }),
         )
         .unwrap();
@@ -112,7 +112,7 @@ mod tests {
     /// Creates a state where the player is in the waiting list.
     fn state_with_waiting_player(pid: PlayerId) -> GameState {
         let mut state = GameState::new(GameId::new(), Shoe::shuffled(), vec![], DealerId::new());
-        state.waiting.push(pid);
+        state.waiting.push((pid, Seat::One));
         state
     }
 

--- a/core/src/domain/engine/command/player/take_seat.rs
+++ b/core/src/domain/engine/command/player/take_seat.rs
@@ -5,11 +5,13 @@ use crate::domain::{
     },
     player::PlayerId,
     table::TableSettings,
+    Seat,
 };
 
 #[derive(Debug, Clone)]
 pub struct TakeSeat {
     pub player_id: PlayerId,
+    pub seat: Seat,
 }
 
 impl CommandHandler for TakeSeat {
@@ -21,16 +23,22 @@ impl CommandHandler for TakeSeat {
         if !state.observers.contains(&self.player_id) {
             return Err(CommandError::PlayerNotFound(self.player_id));
         }
+        if self.seat.index() > settings.max_players {
+            return Err(CommandError::SeatNotAvailable(self.seat, settings.max_players));
+        }
+        if state.players.iter().any(|p| p.seat == self.seat) {
+            return Err(CommandError::SeatOccupied(self.seat));
+        }
 
-        if matches!(state.phase, Phase::WaitingForBets)
-            && state.players.len() < settings.max_players
-        {
+        if matches!(state.phase, Phase::WaitingForBets) {
             Ok(vec![EventPayload::PlayerJoined {
                 player: self.player_id,
+                seat: self.seat,
             }])
         } else {
             Ok(vec![EventPayload::PlayerAddedToWaitingList {
                 player: self.player_id,
+                seat: self.seat,
             }])
         }
     }
@@ -50,7 +58,7 @@ mod tests {
             game_state::GameState,
             GameEngine,
         },
-        Shoe,
+        Seat, Shoe,
     };
 
     fn settings(max_players: usize) -> TableSettings {
@@ -68,11 +76,11 @@ mod tests {
         state
     }
 
-    fn cmd(player_id: PlayerId) -> GameCommand {
+    fn cmd(player_id: PlayerId, seat: Seat) -> GameCommand {
         GameCommand::Player(PlayerCommand {
             game_id: GameId::new(),
             command_id: CommandId(0),
-            action: PlayerAction::TakeSeat(TakeSeat { player_id }),
+            action: PlayerAction::TakeSeat(TakeSeat { player_id, seat }),
         })
     }
 
@@ -80,25 +88,27 @@ mod tests {
     fn take_seat_waiting_for_bets_with_open_slot() {
         let pid = PlayerId::new();
         let state = state_with_observer(pid);
-        let events = GameEngine::handle(&state, &settings(5), &cmd(pid)).unwrap();
+        let events = GameEngine::handle(&state, &settings(5), &cmd(pid, Seat::One)).unwrap();
         assert_eq!(events.len(), 1);
-        assert!(matches!(events[0], EventPayload::PlayerJoined { player } if player == pid));
+        assert!(matches!(events[0], EventPayload::PlayerJoined { player, seat: Seat::One } if player == pid));
     }
 
     #[test]
-    fn take_seat_waiting_for_bets_table_full() {
+    fn take_seat_occupied_errors() {
         let pid = PlayerId::new();
-        let mut state = state_with_observer(pid);
         let other = PlayerId::new();
-        state
-            .players
-            .push(crate::domain::player::PlayerState::new(other));
-        let events = GameEngine::handle(&state, &settings(1), &cmd(pid)).unwrap();
-        assert_eq!(events.len(), 1);
-        assert!(matches!(
-            events[0],
-            EventPayload::PlayerAddedToWaitingList { player } if player == pid
-        ));
+        let mut state = state_with_observer(pid);
+        state.players.push(crate::domain::player::PlayerState::at_seat(other, Seat::One));
+        let err = GameEngine::handle(&state, &settings(5), &cmd(pid, Seat::One)).unwrap_err();
+        assert!(matches!(err, CommandError::SeatOccupied(Seat::One)));
+    }
+
+    #[test]
+    fn take_seat_out_of_range_errors() {
+        let pid = PlayerId::new();
+        let state = state_with_observer(pid);
+        let err = GameEngine::handle(&state, &settings(2), &cmd(pid, Seat::Three)).unwrap_err();
+        assert!(matches!(err, CommandError::SeatNotAvailable(Seat::Three, 2)));
     }
 
     #[test]
@@ -106,11 +116,11 @@ mod tests {
         let pid = PlayerId::new();
         let mut state = state_with_observer(pid);
         state.phase = Phase::PlayerTurn(PlayerId::new());
-        let events = GameEngine::handle(&state, &settings(5), &cmd(pid)).unwrap();
+        let events = GameEngine::handle(&state, &settings(5), &cmd(pid, Seat::Two)).unwrap();
         assert_eq!(events.len(), 1);
         assert!(matches!(
             events[0],
-            EventPayload::PlayerAddedToWaitingList { .. }
+            EventPayload::PlayerAddedToWaitingList { seat: Seat::Two, .. }
         ));
     }
 
@@ -118,7 +128,7 @@ mod tests {
     fn take_seat_not_observer_returns_error() {
         let pid = PlayerId::new();
         let state = GameState::new(GameId::new(), Shoe::shuffled(), vec![], DealerId::new());
-        let err = GameEngine::handle(&state, &settings(5), &cmd(pid)).unwrap_err();
+        let err = GameEngine::handle(&state, &settings(5), &cmd(pid, Seat::One)).unwrap_err();
         assert!(matches!(err, CommandError::PlayerNotFound(_)));
     }
 
@@ -126,12 +136,12 @@ mod tests {
     fn take_seat_removes_from_observers_when_seated() {
         let pid = PlayerId::new();
         let mut state = state_with_observer(pid);
-        let events = GameEngine::handle(&state, &settings(5), &cmd(pid)).unwrap();
+        let events = GameEngine::handle(&state, &settings(5), &cmd(pid, Seat::One)).unwrap();
         for e in &events {
             state.apply_event(e);
         }
         assert!(!state.observers.contains(&pid));
-        assert!(state.players.iter().any(|p| p.player_id == pid));
+        assert!(state.players.iter().any(|p| p.player_id == pid && p.seat == Seat::One));
     }
 
     #[test]
@@ -139,11 +149,11 @@ mod tests {
         let pid = PlayerId::new();
         let mut state = state_with_observer(pid);
         state.phase = Phase::DealerTurn;
-        let events = GameEngine::handle(&state, &settings(5), &cmd(pid)).unwrap();
+        let events = GameEngine::handle(&state, &settings(5), &cmd(pid, Seat::Three)).unwrap();
         for e in &events {
             state.apply_event(e);
         }
         assert!(!state.observers.contains(&pid));
-        assert!(state.waiting.contains(&pid));
+        assert!(state.waiting.iter().any(|(p, s)| *p == pid && *s == Seat::Three));
     }
 }

--- a/core/src/domain/engine/command/player/take_seat.rs
+++ b/core/src/domain/engine/command/player/take_seat.rs
@@ -23,10 +23,15 @@ impl CommandHandler for TakeSeat {
         if !state.observers.contains(&self.player_id) {
             return Err(CommandError::PlayerNotFound(self.player_id));
         }
-        if self.seat.index() > settings.max_players {
-            return Err(CommandError::SeatNotAvailable(self.seat, settings.max_players));
+        if self.seat.number() > settings.max_players {
+            return Err(CommandError::SeatNotAvailable(
+                self.seat,
+                settings.max_players,
+            ));
         }
-        if state.players.iter().any(|p| p.seat == self.seat) {
+        if state.players.iter().any(|p| p.seat == self.seat)
+            || state.waiting.iter().any(|(_, s)| *s == self.seat)
+        {
             return Err(CommandError::SeatOccupied(self.seat));
         }
 
@@ -90,7 +95,9 @@ mod tests {
         let state = state_with_observer(pid);
         let events = GameEngine::handle(&state, &settings(5), &cmd(pid, Seat::One)).unwrap();
         assert_eq!(events.len(), 1);
-        assert!(matches!(events[0], EventPayload::PlayerJoined { player, seat: Seat::One } if player == pid));
+        assert!(
+            matches!(events[0], EventPayload::PlayerJoined { player, seat: Seat::One } if player == pid)
+        );
     }
 
     #[test]
@@ -98,7 +105,12 @@ mod tests {
         let pid = PlayerId::new();
         let other = PlayerId::new();
         let mut state = state_with_observer(pid);
-        state.players.push(crate::domain::player::PlayerState::at_seat(other, Seat::One));
+        state
+            .players
+            .push(crate::domain::player::PlayerState::at_seat(
+                other,
+                Seat::One,
+            ));
         let err = GameEngine::handle(&state, &settings(5), &cmd(pid, Seat::One)).unwrap_err();
         assert!(matches!(err, CommandError::SeatOccupied(Seat::One)));
     }
@@ -108,7 +120,10 @@ mod tests {
         let pid = PlayerId::new();
         let state = state_with_observer(pid);
         let err = GameEngine::handle(&state, &settings(2), &cmd(pid, Seat::Three)).unwrap_err();
-        assert!(matches!(err, CommandError::SeatNotAvailable(Seat::Three, 2)));
+        assert!(matches!(
+            err,
+            CommandError::SeatNotAvailable(Seat::Three, 2)
+        ));
     }
 
     #[test]
@@ -120,7 +135,10 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert!(matches!(
             events[0],
-            EventPayload::PlayerAddedToWaitingList { seat: Seat::Two, .. }
+            EventPayload::PlayerAddedToWaitingList {
+                seat: Seat::Two,
+                ..
+            }
         ));
     }
 
@@ -141,7 +159,10 @@ mod tests {
             state.apply_event(e);
         }
         assert!(!state.observers.contains(&pid));
-        assert!(state.players.iter().any(|p| p.player_id == pid && p.seat == Seat::One));
+        assert!(state
+            .players
+            .iter()
+            .any(|p| p.player_id == pid && p.seat == Seat::One));
     }
 
     #[test]
@@ -154,6 +175,9 @@ mod tests {
             state.apply_event(e);
         }
         assert!(!state.observers.contains(&pid));
-        assert!(state.waiting.iter().any(|(p, s)| *p == pid && *s == Seat::Three));
+        assert!(state
+            .waiting
+            .iter()
+            .any(|(p, s)| *p == pid && *s == Seat::Three));
     }
 }

--- a/core/src/domain/engine/error.rs
+++ b/core/src/domain/engine/error.rs
@@ -25,4 +25,8 @@ pub enum CommandError {
     ObserversFull,
     #[error("no players have placed bets")]
     NoBettors,
+    #[error("seat {0} is already occupied")]
+    SeatOccupied(crate::domain::Seat),
+    #[error("seat {0} is not available at this table (max {1} players)")]
+    SeatNotAvailable(crate::domain::Seat, usize),
 }

--- a/core/src/domain/engine/event/payload.rs
+++ b/core/src/domain/engine/event/payload.rs
@@ -2,7 +2,7 @@ use crate::domain::{
     dealer::DealerId,
     engine::{action::PlayerDecision, phase::Phase},
     player::PlayerId,
-    Card,
+    Card, Seat,
 };
 
 use super::outcome::GameResult;
@@ -11,6 +11,7 @@ use super::outcome::GameResult;
 pub enum EventPayload {
     PlayerJoined {
         player: PlayerId,
+        seat: Seat,
     },
     PlayerLeft {
         player: PlayerId,
@@ -23,6 +24,7 @@ pub enum EventPayload {
     },
     PlayerAddedToWaitingList {
         player: PlayerId,
+        seat: Seat,
     },
     PlayerRemovedFromWaitingList {
         player: PlayerId,

--- a/core/src/domain/engine/game_state.rs
+++ b/core/src/domain/engine/game_state.rs
@@ -22,6 +22,11 @@ pub struct GameState {
 
 impl GameState {
     pub fn new(game_id: GameId, shoe: Vec<Card>, players: Vec<PlayerId>, dealer: DealerId) -> Self {
+        debug_assert!(
+            players.len() <= Seat::ALL.len(),
+            "more players than seats: {}",
+            players.len()
+        );
         Self {
             game_id,
             phase: Phase::WaitingForBets,
@@ -45,6 +50,11 @@ impl GameState {
         players: Vec<(PlayerId, u32)>,
         dealer: DealerId,
     ) -> Self {
+        debug_assert!(
+            players.len() <= Seat::ALL.len(),
+            "more players than seats: {}",
+            players.len()
+        );
         Self {
             game_id,
             phase: Phase::WaitingForBets,
@@ -53,7 +63,9 @@ impl GameState {
             players: players
                 .into_iter()
                 .enumerate()
-                .map(|(i, (id, balance))| PlayerState::with_balance_at_seat(id, Seat::ALL[i], balance))
+                .map(|(i, (id, balance))| {
+                    PlayerState::with_balance_at_seat(id, Seat::ALL[i], balance)
+                })
                 .collect(),
             dealer: DealerState::new(dealer),
             observers: vec![],
@@ -79,6 +91,7 @@ impl GameState {
             }
             EventPayload::PlayerLeft { player } => {
                 self.players.retain(|p| p.player_id != *player);
+                self.waiting.retain(|(p, _)| *p != *player);
             }
             EventPayload::ObserverJoined { player } => {
                 self.observers.push(*player);

--- a/core/src/domain/engine/game_state.rs
+++ b/core/src/domain/engine/game_state.rs
@@ -2,7 +2,7 @@ use crate::domain::{
     dealer::{DealerId, DealerState},
     engine::{game_id::GameId, phase::Phase},
     player::{PlayerId, PlayerState},
-    Card,
+    Card, Seat,
 };
 
 use super::event::EventPayload;
@@ -16,7 +16,8 @@ pub struct GameState {
     pub players: Vec<PlayerState>,
     pub dealer: DealerState,
     pub observers: Vec<PlayerId>,
-    pub waiting: Vec<PlayerId>,
+    /// (player_id, desired_seat) — seat is remembered so OpenBetting can restore the player to their preferred position.
+    pub waiting: Vec<(PlayerId, Seat)>,
 }
 
 impl GameState {
@@ -26,7 +27,11 @@ impl GameState {
             phase: Phase::WaitingForBets,
             shoe,
             dealt: 0,
-            players: players.into_iter().map(PlayerState::new).collect(),
+            players: players
+                .into_iter()
+                .enumerate()
+                .map(|(i, id)| PlayerState::at_seat(id, Seat::ALL[i]))
+                .collect(),
             dealer: DealerState::new(dealer),
             observers: vec![],
             waiting: vec![],
@@ -47,7 +52,8 @@ impl GameState {
             dealt: 0,
             players: players
                 .into_iter()
-                .map(|(id, balance)| PlayerState::with_balance(id, balance))
+                .enumerate()
+                .map(|(i, (id, balance))| PlayerState::with_balance_at_seat(id, Seat::ALL[i], balance))
                 .collect(),
             dealer: DealerState::new(dealer),
             observers: vec![],
@@ -66,10 +72,10 @@ impl GameState {
 
     pub fn apply_event(&mut self, payload: &EventPayload) {
         match payload {
-            EventPayload::PlayerJoined { player } => {
+            EventPayload::PlayerJoined { player, seat } => {
                 self.observers.retain(|&p| p != *player);
-                self.waiting.retain(|&p| p != *player);
-                self.players.push(PlayerState::new(*player));
+                self.waiting.retain(|(p, _)| *p != *player);
+                self.players.push(PlayerState::at_seat(*player, *seat));
             }
             EventPayload::PlayerLeft { player } => {
                 self.players.retain(|p| p.player_id != *player);
@@ -80,12 +86,12 @@ impl GameState {
             EventPayload::ObserverLeft { player } => {
                 self.observers.retain(|&p| p != *player);
             }
-            EventPayload::PlayerAddedToWaitingList { player } => {
+            EventPayload::PlayerAddedToWaitingList { player, seat } => {
                 self.observers.retain(|&p| p != *player);
-                self.waiting.push(*player);
+                self.waiting.push((*player, *seat));
             }
             EventPayload::PlayerRemovedFromWaitingList { player } => {
-                self.waiting.retain(|&p| p != *player);
+                self.waiting.retain(|(p, _)| *p != *player);
             }
             EventPayload::PlayerPlacedBet { player, amount } => {
                 if let Some(player_state) = self.players.iter_mut().find(|p| p.player_id == *player)

--- a/core/src/domain/engine/mod.rs
+++ b/core/src/domain/engine/mod.rs
@@ -6,6 +6,7 @@ pub mod game_engine;
 pub mod game_id;
 pub mod game_state;
 pub mod phase;
+pub mod snapshot;
 
 pub use action::PlayerDecision;
 pub use command::{
@@ -18,3 +19,4 @@ pub use game_engine::GameEngine;
 pub use game_id::GameId;
 pub use game_state::GameState;
 pub use phase::Phase;
+pub use snapshot::{GameEventDto, GameStateSnapshot};

--- a/core/src/domain/engine/snapshot.rs
+++ b/core/src/domain/engine/snapshot.rs
@@ -33,7 +33,8 @@ pub struct GameStateSnapshot {
     pub dealer: DealerSnapshot,
     pub requesting_player: PlayerId,
     pub observers: Vec<PlayerId>,
-    pub waiting: Vec<PlayerId>,
+    /// Players waiting to join the next round, with their reserved seat.
+    pub waiting: Vec<(PlayerId, Seat)>,
 }
 
 impl GameStateSnapshot {
@@ -73,7 +74,7 @@ impl GameStateSnapshot {
             },
             requesting_player,
             observers: state.observers.clone(),
-            waiting: state.waiting.iter().map(|(p, _)| *p).collect(),
+            waiting: state.waiting.clone(),
         }
     }
 }

--- a/core/src/domain/engine/snapshot.rs
+++ b/core/src/domain/engine/snapshot.rs
@@ -1,0 +1,84 @@
+use serde::{Deserialize, Serialize};
+
+use crate::domain::{
+    dealer::DealerId,
+    engine::{event::payload::EventPayload, game_id::GameId, game_state::GameState, phase::Phase},
+    player::PlayerId,
+    Card,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlayerSnapshot {
+    pub player_id: PlayerId,
+    pub balance: u32,
+    pub bet: Option<u32>,
+    pub cards: Vec<Card>,
+    pub hand_value: u8,
+    pub is_bust: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DealerSnapshot {
+    pub dealer_id: DealerId,
+    /// First card always visible. Second card hidden (None) until DealerTurn.
+    pub cards: Vec<Option<Card>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GameStateSnapshot {
+    pub game_id: GameId,
+    pub phase: Phase,
+    pub players: Vec<PlayerSnapshot>,
+    pub dealer: DealerSnapshot,
+    pub requesting_player: PlayerId,
+    pub observers: Vec<PlayerId>,
+    pub waiting: Vec<PlayerId>,
+}
+
+impl GameStateSnapshot {
+    pub fn from_state(state: &GameState, requesting_player: PlayerId) -> Self {
+        let hide_hole = matches!(state.phase, Phase::InitialDealing | Phase::PlayerTurn(_));
+
+        let players = state
+            .players
+            .iter()
+            .map(|p| PlayerSnapshot {
+                player_id: p.player_id,
+                balance: p.balance,
+                bet: p.bet,
+                cards: p.hand.cards.clone(),
+                hand_value: p.hand.value().best_value(),
+                is_bust: p.hand.value().is_bust(),
+            })
+            .collect();
+
+        let dealer_cards: Vec<Option<Card>> = state
+            .dealer
+            .hand
+            .cards
+            .iter()
+            .enumerate()
+            .map(|(i, &c)| if hide_hole && i == 1 { None } else { Some(c) })
+            .collect();
+
+        GameStateSnapshot {
+            game_id: state.game_id,
+            phase: state.phase.clone(),
+            players,
+            dealer: DealerSnapshot {
+                dealer_id: state.dealer.dealer_id,
+                cards: dealer_cards,
+            },
+            requesting_player,
+            observers: state.observers.clone(),
+            waiting: state.waiting.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GameEventDto {
+    pub game_id: GameId,
+    pub seq: u64,
+    pub payload: EventPayload,
+}

--- a/core/src/domain/engine/snapshot.rs
+++ b/core/src/domain/engine/snapshot.rs
@@ -4,12 +4,13 @@ use crate::domain::{
     dealer::DealerId,
     engine::{event::payload::EventPayload, game_id::GameId, game_state::GameState, phase::Phase},
     player::PlayerId,
-    Card,
+    Card, Seat,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlayerSnapshot {
     pub player_id: PlayerId,
+    pub seat: Seat,
     pub balance: u32,
     pub bet: Option<u32>,
     pub cards: Vec<Card>,
@@ -44,6 +45,7 @@ impl GameStateSnapshot {
             .iter()
             .map(|p| PlayerSnapshot {
                 player_id: p.player_id,
+                seat: p.seat,
                 balance: p.balance,
                 bet: p.bet,
                 cards: p.hand.cards.clone(),
@@ -71,7 +73,7 @@ impl GameStateSnapshot {
             },
             requesting_player,
             observers: state.observers.clone(),
-            waiting: state.waiting.clone(),
+            waiting: state.waiting.iter().map(|(p, _)| *p).collect(),
         }
     }
 }

--- a/core/src/domain/engine/snapshot.rs
+++ b/core/src/domain/engine/snapshot.rs
@@ -82,3 +82,74 @@ pub struct GameEventDto {
     pub seq: u64,
     pub payload: EventPayload,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        card::{Card, DeckId, Rank, Shoe, Suit},
+        dealer::DealerId,
+        engine::{game_id::GameId, game_state::GameState, phase::Phase},
+        player::PlayerId,
+    };
+
+    fn state_with_dealer_two_cards() -> (GameState, Card, Card) {
+        let mut state = GameState::new(GameId::new(), Shoe::shuffled(), vec![], DealerId::new());
+        let face_up = Card::new(DeckId::One, Suit::Spades, Rank::Ten);
+        let hole = Card::new(DeckId::One, Suit::Hearts, Rank::Ace);
+        state.dealer.hand.add_card(face_up);
+        state.dealer.hand.add_card(hole);
+        (state, face_up, hole)
+    }
+
+    #[test]
+    fn hole_card_hidden_during_initial_dealing() {
+        let (mut state, face_up, _) = state_with_dealer_two_cards();
+        state.phase = Phase::InitialDealing;
+        let snap = GameStateSnapshot::from_state(&state, PlayerId::new());
+        assert_eq!(snap.dealer.cards[0], Some(face_up));
+        assert_eq!(
+            snap.dealer.cards[1], None,
+            "hole card must be hidden during InitialDealing"
+        );
+    }
+
+    #[test]
+    fn hole_card_hidden_during_player_turn() {
+        let (mut state, _, _) = state_with_dealer_two_cards();
+        state.phase = Phase::PlayerTurn(PlayerId::new());
+        let snap = GameStateSnapshot::from_state(&state, PlayerId::new());
+        assert_eq!(
+            snap.dealer.cards[1], None,
+            "hole card must be hidden during PlayerTurn"
+        );
+    }
+
+    #[test]
+    fn hole_card_visible_during_dealer_turn() {
+        let (mut state, _, hole) = state_with_dealer_two_cards();
+        state.phase = Phase::DealerTurn;
+        let snap = GameStateSnapshot::from_state(&state, PlayerId::new());
+        assert_eq!(
+            snap.dealer.cards[1],
+            Some(hole),
+            "hole card must be visible during DealerTurn"
+        );
+    }
+
+    #[test]
+    fn hole_card_visible_during_payouts() {
+        let (mut state, _, hole) = state_with_dealer_two_cards();
+        state.phase = Phase::Payouts;
+        let snap = GameStateSnapshot::from_state(&state, PlayerId::new());
+        assert_eq!(snap.dealer.cards[1], Some(hole));
+    }
+
+    #[test]
+    fn hole_card_visible_after_finished() {
+        let (mut state, _, hole) = state_with_dealer_two_cards();
+        state.phase = Phase::Finished;
+        let snap = GameStateSnapshot::from_state(&state, PlayerId::new());
+        assert_eq!(snap.dealer.cards[1], Some(hole));
+    }
+}

--- a/core/src/domain/mod.rs
+++ b/core/src/domain/mod.rs
@@ -3,6 +3,7 @@ mod dealer;
 pub mod engine;
 pub mod hand;
 mod player;
+mod seat;
 mod table;
 
 pub use card::*;
@@ -11,4 +12,5 @@ pub use engine::GameId;
 pub use engine::GameState;
 pub use hand::Hand;
 pub use player::*;
+pub use seat::Seat;
 pub use table::*;

--- a/core/src/domain/player/player_state.rs
+++ b/core/src/domain/player/player_state.rs
@@ -1,8 +1,11 @@
-use crate::domain::{engine::action::PlayerDecision, hand::Hand, player::PlayerId};
+use crate::domain::{engine::action::PlayerDecision, hand::Hand, player::PlayerId, Seat};
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PlayerState {
     pub player_id: PlayerId,
+    /// Physical seat at the table. Multiple entries with the same player_id but different
+    /// seats represent a player holding multiple hands simultaneously.
+    pub seat: Seat,
     pub hand: Hand,
     pub balance: u32,
     pub bet: Option<u32>,
@@ -11,12 +14,21 @@ pub struct PlayerState {
 
 impl PlayerState {
     pub fn new(player_id: PlayerId) -> Self {
-        Self::with_balance(player_id, 0)
+        Self::at_seat(player_id, Seat::One)
+    }
+
+    pub fn at_seat(player_id: PlayerId, seat: Seat) -> Self {
+        Self::with_balance_at_seat(player_id, seat, 0)
     }
 
     pub fn with_balance(player_id: PlayerId, balance: u32) -> Self {
+        Self::with_balance_at_seat(player_id, Seat::One, balance)
+    }
+
+    pub fn with_balance_at_seat(player_id: PlayerId, seat: Seat, balance: u32) -> Self {
         Self {
             player_id,
+            seat,
             hand: Hand::new(),
             balance,
             bet: None,

--- a/core/src/domain/seat.rs
+++ b/core/src/domain/seat.rs
@@ -1,0 +1,39 @@
+/// One of the seven physical seat positions at a blackjack table.
+///
+/// Variants are ordered left-to-right from the dealer's perspective, which is the
+/// canonical deal order. `Ord` reflects that order, so sorting by `Seat` gives the
+/// correct dealing sequence without any extra mapping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]
+pub enum Seat {
+    One = 1,
+    Two = 2,
+    Three = 3,
+    Four = 4,
+    Five = 5,
+    Six = 6,
+    Seven = 7,
+}
+
+impl Seat {
+    /// All seats in deal order.
+    pub const ALL: [Seat; 7] = [
+        Seat::One,
+        Seat::Two,
+        Seat::Three,
+        Seat::Four,
+        Seat::Five,
+        Seat::Six,
+        Seat::Seven,
+    ];
+
+    /// 1-indexed position used for bounds checks against `TableSettings::max_players`.
+    pub fn index(self) -> usize {
+        self as usize
+    }
+}
+
+impl std::fmt::Display for Seat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.index())
+    }
+}

--- a/core/src/domain/seat.rs
+++ b/core/src/domain/seat.rs
@@ -3,7 +3,9 @@
 /// Variants are ordered left-to-right from the dealer's perspective, which is the
 /// canonical deal order. `Ord` reflects that order, so sorting by `Seat` gives the
 /// correct dealing sequence without any extra mapping.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
 pub enum Seat {
     One = 1,
     Two = 2,
@@ -26,14 +28,15 @@ impl Seat {
         Seat::Seven,
     ];
 
-    /// 1-indexed position used for bounds checks against `TableSettings::max_players`.
-    pub fn index(self) -> usize {
+    /// 1-based seat number (1–7), used for bounds checks against `TableSettings::max_players`.
+    /// Named `number` rather than `index` to avoid implying 0-based indexing.
+    pub fn number(self) -> usize {
         self as usize
     }
 }
 
 impl std::fmt::Display for Seat {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.index())
+        write!(f, "{}", self.number())
     }
 }


### PR DESCRIPTION
Sixth of 11 stacked PRs. Targets `pr/05-core-settlement`.

Adds two types for wire serialisation to WebSocket clients:

- **GameStateSnapshot** — point-in-time view of game state that hides the dealer hole card during `InitialDealing` and `PlayerTurn` phases; reveals it from `DealerTurn` onward
- **GameEventDto** — wraps `EventPayload` with `game_id` and sequence number for ordered delivery over WebSocket

93 unit tests pass (no new tests needed — types are pure data projections).