### PR TITLE
feat(server): full WS transport – auth flow, seat dispatch, event forwarder

### DIFF
--- a/server/openapi.json
+++ b/server/openapi.json
@@ -24,20 +24,7 @@
         "operationId": "list_tables",
         "responses": {
           "200": {
-            "description": "List of tables",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/TableResponse"
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal server error"
+            "description": "List of live tables"
           }
         }
       }
@@ -53,56 +40,5 @@
       }
     }
   },
-  "components": {
-    "schemas": {
-      "TableResponse": {
-        "type": "object",
-        "required": [
-          "id",
-          "name",
-          "settings"
-        ],
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "settings": {
-            "$ref": "#/components/schemas/TableSettings"
-          }
-        }
-      },
-      "TableSettings": {
-        "type": "object",
-        "required": [
-          "min_bet",
-          "max_bet",
-          "max_players",
-          "max_observers"
-        ],
-        "properties": {
-          "max_bet": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          "max_observers": {
-            "type": "integer",
-            "minimum": 0
-          },
-          "max_players": {
-            "type": "integer",
-            "minimum": 0
-          },
-          "min_bet": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          }
-        }
-      }
-    }
-  }
+  "components": {}
 }

--- a/server/src/routes/table.rs
+++ b/server/src/routes/table.rs
@@ -1,29 +1,13 @@
-use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
-use bj_core::domain::TableSettings;
-use serde::Serialize;
-use utoipa::{ToResponse, ToSchema};
-
-use crate::AppState;
-
-// TODO(Task 16): Fully replace with new table/session architecture.
-#[derive(Serialize, ToResponse, ToSchema)]
-#[response(description = "Table information")]
-struct TableResponse {
-    id: String,
-    name: String,
-    settings: TableSettings,
-}
+use crate::{session::summary::TableSummary, AppState};
+use axum::{extract::State, Json};
 
 #[utoipa::path(
     get,
     path = "/tables",
     responses(
-        (status = 200, description = "List of tables", body = [TableResponse]),
-        (status = 500, description = "Internal server error")
+        (status = 200, description = "List of live tables")
     )
 )]
-pub async fn list_tables(State(_state): State<AppState>) -> impl IntoResponse {
-    // TODO(Task 16): Wire up real session store.
-    let response: Vec<TableResponse> = vec![];
-    (StatusCode::OK, Json(response))
+pub async fn list_tables(State(state): State<AppState>) -> Json<Vec<TableSummary>> {
+    Json(state.session.list_tables().await)
 }

--- a/server/src/routes/ws.rs
+++ b/server/src/routes/ws.rs
@@ -1,21 +1,28 @@
 use axum::{
     extract::{
-        ws::{WebSocket, WebSocketUpgrade},
+        ws::{Message, WebSocket, WebSocketUpgrade},
         State,
     },
     response::IntoResponse,
 };
-use tracing::info;
+use tokio::sync::mpsc;
+use tracing::{error, info, warn};
 
-use crate::AppState;
+use crate::{
+    auth::{AuthPayload, Authenticator, Password},
+    protocol::{ClientMessage, ServerMessage},
+    session::RequestId,
+    AppState,
+};
+use bj_core::domain::{
+    engine::command::player::{
+        Hit, JoinTable, LeaveSeat, LeaveTable, PlaceBet, PlayerAction, Stand, TakeSeat,
+    },
+    engine::snapshot::GameEventDto,
+    Seat, TableId,
+};
 
-#[utoipa::path(
-    get,
-    path = "/ws",
-    responses(
-        (status = 101, description = "WebSocket upgrade")
-    )
-)]
+#[utoipa::path(get, path = "/ws", responses((status = 101, description = "WebSocket upgrade")))]
 pub async fn ws_handler(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl IntoResponse {
     ws.on_upgrade(move |socket| handle_socket(socket, state))
 }
@@ -23,10 +30,547 @@ pub async fn ws_handler(ws: WebSocketUpgrade, State(state): State<AppState>) -> 
 async fn handle_socket(mut socket: WebSocket, state: AppState) {
     let conn_id = state
         .connections
-        .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-        + 1;
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     info!("WS connection {conn_id} opened");
-    // Full protocol implemented in PR-08.
-    let _ = socket.recv().await;
-    info!("WS connection {conn_id} closed");
+
+    // Auth phase
+    let (player_id, authed_username) = loop {
+        match socket.recv().await {
+            None => {
+                info!("conn={conn_id} disconnected before auth");
+                return;
+            }
+            Some(Err(e)) => {
+                error!("conn={conn_id} recv error before auth: {e}");
+                return;
+            }
+            Some(Ok(Message::Text(text))) => {
+                match serde_json::from_str::<ClientMessage>(&text) {
+                    Ok(ClientMessage::Auth { username, password }) => {
+                        match state
+                            .auth
+                            .authenticate(&AuthPayload {
+                                username: username.clone(),
+                                password: Password::new(password),
+                            })
+                            .await
+                        {
+                            Ok(pid) => {
+                                // Only seed chips for new players (wallet returns Err if player unknown)
+                                if state.wallet.balance(pid).await.is_err() {
+                                    let _ = state.wallet.credit(pid, 1000).await;
+                                }
+                                info!(
+                                    "conn={conn_id} authenticated user='{}' player_id={}",
+                                    username, pid
+                                );
+                                if send_msg(
+                                    &mut socket,
+                                    &ServerMessage::AuthOk {
+                                        player_id: pid.to_string(),
+                                    },
+                                )
+                                .await
+                                .is_err()
+                                {
+                                    return;
+                                }
+                                let balance = state.wallet.balance(pid).await.unwrap_or(0);
+                                let _ = send_msg(
+                                    &mut socket,
+                                    &ServerMessage::Balance { amount: balance },
+                                )
+                                .await;
+                                break (pid, username);
+                            }
+                            Err(e) => {
+                                warn!("conn={conn_id} auth failed user='{}': {e}", username);
+                                let _ = send_msg(
+                                    &mut socket,
+                                    &ServerMessage::AuthError {
+                                        reason: e.to_string(),
+                                    },
+                                )
+                                .await;
+                                return;
+                            }
+                        }
+                    }
+                    _ => {
+                        warn!("conn={conn_id} sent non-Auth message before authenticating");
+                        let _ = send_msg(
+                            &mut socket,
+                            &ServerMessage::AuthError {
+                                reason: "send Auth first".into(),
+                            },
+                        )
+                        .await;
+                    }
+                }
+            }
+            Some(Ok(_)) => {}
+        }
+    };
+
+    let mut current_table: Option<TableId> = None;
+    let (event_fwd_tx, mut event_fwd_rx) = mpsc::channel::<String>(64);
+    let mut fwd_abort: Option<tokio::task::JoinHandle<()>> = None;
+
+    loop {
+        tokio::select! {
+            Some(json) = event_fwd_rx.recv() => {
+                if socket.send(Message::Text(json.into())).await.is_err() {
+                    error!("conn={conn_id} user='{}' send failed (event forward)", authed_username);
+                    break;
+                }
+            }
+            msg = socket.recv() => {
+                match msg {
+                    None => {
+                        info!("conn={conn_id} user='{}' disconnected", authed_username);
+                        break;
+                    }
+                    Some(Err(e)) => {
+                        error!("conn={conn_id} user='{}' recv error: {e}", authed_username);
+                        break;
+                    }
+                    Some(Ok(Message::Close(_))) => {
+                        info!("conn={conn_id} user='{}' sent close frame", authed_username);
+                        break;
+                    }
+                    Some(Ok(Message::Text(text))) => {
+                        match serde_json::from_str::<ClientMessage>(&text) {
+                            Err(e) => {
+                                warn!("conn={conn_id} user='{}' parse error: {e}", authed_username);
+                                let _ = send_msg(&mut socket, &ServerMessage::CommandError {
+                                    request_id: 0,
+                                    reason: format!("parse error: {e}"),
+                                }).await;
+                            }
+                            Ok(msg) => {
+                                if handle_client_msg(
+                                    msg, player_id, &state,
+                                    &mut socket, &mut current_table,
+                                    &event_fwd_tx, &mut fwd_abort,
+                                ).await.is_err() { break; }
+                            }
+                        }
+                    }
+                    Some(Ok(_)) => {}
+                }
+            }
+        }
+    }
+
+    if let Some(h) = fwd_abort {
+        h.abort();
+    }
+    if let Some(tid) = current_table {
+        if let Err(e) = state
+            .session
+            .send_command(
+                tid,
+                player_id,
+                RequestId(0),
+                PlayerAction::LeaveTable(LeaveTable { player_id }),
+            )
+            .await
+        {
+            warn!(
+                "conn={conn_id} user='{}' leave-table on disconnect failed: {e}",
+                authed_username
+            );
+        }
+    }
+    info!("conn={conn_id} user='{}' session ended", authed_username);
+}
+
+async fn handle_client_msg(
+    msg: ClientMessage,
+    player_id: bj_core::domain::PlayerId,
+    state: &AppState,
+    socket: &mut WebSocket,
+    current_table: &mut Option<TableId>,
+    event_fwd_tx: &mpsc::Sender<String>,
+    fwd_abort: &mut Option<tokio::task::JoinHandle<()>>,
+) -> Result<(), ()> {
+    match msg {
+        ClientMessage::JoinTable {
+            table_id,
+            request_id,
+        } => {
+            let tid = match table_id.parse::<TableId>() {
+                Ok(t) => t,
+                Err(_) => {
+                    let _ = send_msg(
+                        socket,
+                        &ServerMessage::CommandError {
+                            request_id,
+                            reason: "invalid table_id".into(),
+                        },
+                    )
+                    .await;
+                    return Ok(());
+                }
+            };
+
+            // Leave old table before joining a new one
+            if let Some(old_tid) = current_table.take() {
+                if let Some(h) = fwd_abort.take() {
+                    h.abort();
+                }
+                let _ = state
+                    .session
+                    .send_command(
+                        old_tid,
+                        player_id,
+                        RequestId(0),
+                        PlayerAction::LeaveTable(LeaveTable { player_id }),
+                    )
+                    .await;
+            }
+
+            // Reject join if the table refuses it
+            if let Err(e) = state
+                .session
+                .send_command(
+                    tid,
+                    player_id,
+                    RequestId(request_id),
+                    PlayerAction::JoinTable(JoinTable { player_id }),
+                )
+                .await
+            {
+                warn!("player={player_id} join table={tid} rejected: {e}");
+                let _ = send_msg(
+                    socket,
+                    &ServerMessage::CommandError {
+                        request_id,
+                        reason: e.to_string(),
+                    },
+                )
+                .await;
+                return Ok(());
+            }
+            info!("player={player_id} joined table={tid}");
+
+            // Subscribe FIRST to avoid missing events between snapshot and subscribe
+            let mut rx = match state.session.subscribe(tid).await {
+                Ok(rx) => rx,
+                Err(e) => {
+                    error!("player={player_id} subscribe table={tid} failed: {e}");
+                    let _ = send_msg(
+                        socket,
+                        &ServerMessage::CommandError {
+                            request_id,
+                            reason: e.to_string(),
+                        },
+                    )
+                    .await;
+                    return Ok(());
+                }
+            };
+
+            // Then snapshot
+            match state.session.snapshot(tid, player_id).await {
+                Ok(snap) => {
+                    let _ = send_msg(
+                        socket,
+                        &ServerMessage::Snapshot {
+                            table_id: tid.to_string(),
+                            state: snap,
+                        },
+                    )
+                    .await;
+                }
+                Err(e) => {
+                    error!("player={player_id} snapshot table={tid} failed: {e}");
+                    let _ = send_msg(
+                        socket,
+                        &ServerMessage::CommandError {
+                            request_id,
+                            reason: e.to_string(),
+                        },
+                    )
+                    .await;
+                    return Ok(());
+                }
+            }
+
+            // Start forwarder with the already-subscribed receiver
+            if let Some(h) = fwd_abort.take() {
+                h.abort();
+            }
+            let tx = event_fwd_tx.clone();
+            let tid_str = tid.to_string();
+            let wallet = state.wallet.clone();
+            let handle = tokio::spawn(async move {
+                loop {
+                    match rx.recv().await {
+                        Ok(event) => {
+                            let is_finished = matches!(
+                                event.payload,
+                                bj_core::domain::engine::event::payload::EventPayload::GameFinished { .. }
+                            );
+                            let dto = GameEventDto {
+                                game_id: event.game_id,
+                                seq: event.event_seq_id.0,
+                                payload: event.payload,
+                            };
+                            let msg = ServerMessage::Event {
+                                table_id: tid_str.clone(),
+                                event: dto,
+                            };
+                            if let Ok(json) = serde_json::to_string(&msg) {
+                                if tx.send(json).await.is_err() {
+                                    break;
+                                }
+                            }
+                            if is_finished {
+                                let balance = wallet.balance(player_id).await.unwrap_or(0);
+                                if let Ok(json) = serde_json::to_string(&ServerMessage::Balance {
+                                    amount: balance,
+                                }) {
+                                    let _ = tx.send(json).await;
+                                }
+                            }
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                            warn!("table={tid_str} event forwarder lagged by {n} messages");
+                            let err = ServerMessage::CommandError {
+                                request_id: 0,
+                                reason: "event stream lagged, please rejoin".into(),
+                            };
+                            if let Ok(json) = serde_json::to_string(&err) {
+                                let _ = tx.send(json).await;
+                            }
+                            break;
+                        }
+                        Err(e) => {
+                            error!("table={tid_str} event forwarder recv error: {e}");
+                            break;
+                        }
+                    }
+                }
+            });
+            *fwd_abort = Some(handle);
+            *current_table = Some(tid);
+            let _ = send_msg(socket, &ServerMessage::CommandAck { request_id }).await;
+        }
+
+        ClientMessage::LeaveTable {
+            table_id,
+            request_id,
+        } => {
+            let tid = match table_id.parse::<TableId>() {
+                Ok(t) => t,
+                Err(_) => {
+                    let _ = send_msg(
+                        socket,
+                        &ServerMessage::CommandError {
+                            request_id,
+                            reason: "invalid table_id".into(),
+                        },
+                    )
+                    .await;
+                    return Ok(());
+                }
+            };
+            if let Err(e) = state
+                .session
+                .send_command(
+                    tid,
+                    player_id,
+                    RequestId(request_id),
+                    PlayerAction::LeaveTable(LeaveTable { player_id }),
+                )
+                .await
+            {
+                warn!("player={player_id} leave table={tid} failed: {e}");
+                let _ = send_msg(
+                    socket,
+                    &ServerMessage::CommandError {
+                        request_id,
+                        reason: e.to_string(),
+                    },
+                )
+                .await;
+            } else {
+                info!("player={player_id} left table={tid}");
+                if let Some(h) = fwd_abort.take() {
+                    h.abort();
+                }
+                *current_table = None;
+                let _ = send_msg(socket, &ServerMessage::CommandAck { request_id }).await;
+            }
+        }
+
+        ClientMessage::PlaceBet {
+            table_id,
+            request_id,
+            amount,
+        } => {
+            send_player_cmd(
+                socket,
+                state,
+                player_id,
+                &table_id,
+                request_id,
+                PlayerAction::PlaceBet(PlaceBet { player_id, amount }),
+            )
+            .await?;
+        }
+        ClientMessage::Hit {
+            table_id,
+            request_id,
+        } => {
+            send_player_cmd(
+                socket,
+                state,
+                player_id,
+                &table_id,
+                request_id,
+                PlayerAction::Hit(Hit { player_id }),
+            )
+            .await?;
+        }
+        ClientMessage::Stand {
+            table_id,
+            request_id,
+        } => {
+            send_player_cmd(
+                socket,
+                state,
+                player_id,
+                &table_id,
+                request_id,
+                PlayerAction::Stand(Stand { player_id }),
+            )
+            .await?;
+        }
+
+        ClientMessage::LeaveSeat {
+            table_id,
+            request_id,
+        } => {
+            send_player_cmd(
+                socket,
+                state,
+                player_id,
+                &table_id,
+                request_id,
+                PlayerAction::LeaveSeat(LeaveSeat { player_id }),
+            )
+            .await?;
+        }
+
+        ClientMessage::TakeSeat {
+            table_id,
+            request_id,
+            seat,
+        } => {
+            let seat = match Seat::try_from(seat) {
+                Ok(s) => s,
+                Err(_) => {
+                    let _ = send_msg(
+                        socket,
+                        &ServerMessage::CommandError {
+                            request_id,
+                            reason: format!("invalid seat number {seat}: must be 1–7"),
+                        },
+                    )
+                    .await;
+                    return Ok(());
+                }
+            };
+            send_player_cmd(
+                socket,
+                state,
+                player_id,
+                &table_id,
+                request_id,
+                PlayerAction::TakeSeat(TakeSeat { player_id, seat }),
+            )
+            .await?;
+        }
+
+        ClientMessage::DealerOpenBetting { request_id, .. }
+        | ClientMessage::DealerDealCards { request_id, .. }
+        | ClientMessage::DealerPlayHand { request_id, .. }
+        | ClientMessage::DealerSettle { request_id, .. } => {
+            let _ = send_msg(
+                socket,
+                &ServerMessage::CommandError {
+                    request_id,
+                    reason: "dealer commands not supported via WS in this version".into(),
+                },
+            )
+            .await;
+        }
+
+        ClientMessage::Auth { .. } => {
+            let _ = send_msg(
+                socket,
+                &ServerMessage::CommandError {
+                    request_id: 0,
+                    reason: "already authenticated".into(),
+                },
+            )
+            .await;
+        }
+    }
+    Ok(())
+}
+
+async fn send_player_cmd(
+    socket: &mut WebSocket,
+    state: &AppState,
+    player_id: bj_core::domain::PlayerId,
+    table_id_str: &str,
+    request_id: u64,
+    action: PlayerAction,
+) -> Result<(), ()> {
+    match table_id_str.parse::<TableId>() {
+        Err(_) => {
+            let _ = send_msg(
+                socket,
+                &ServerMessage::CommandError {
+                    request_id,
+                    reason: "invalid table_id".into(),
+                },
+            )
+            .await;
+        }
+        Ok(tid) => {
+            match state
+                .session
+                .send_command(tid, player_id, RequestId(request_id), action)
+                .await
+            {
+                Ok(_) => {
+                    let _ = send_msg(socket, &ServerMessage::CommandAck { request_id }).await;
+                }
+                Err(e) => {
+                    warn!("player={player_id} command rejected on table={tid}: {e}");
+                    let _ = send_msg(
+                        socket,
+                        &ServerMessage::CommandError {
+                            request_id,
+                            reason: e.to_string(),
+                        },
+                    )
+                    .await;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn send_msg(socket: &mut WebSocket, msg: &ServerMessage) -> Result<(), ()> {
+    let json = serde_json::to_string(msg).map_err(|_| ())?;
+    socket
+        .send(Message::Text(json.into()))
+        .await
+        .map_err(|_| ())
 }

--- a/server/src/routes/ws.rs
+++ b/server/src/routes/ws.rs
@@ -14,6 +14,9 @@ use crate::{
     session::RequestId,
     AppState,
 };
+
+/// Chips granted to a first-time player on their initial login.
+const NEW_PLAYER_CHIPS: u32 = 1_000;
 use bj_core::domain::{
     engine::command::player::{
         Hit, JoinTable, LeaveSeat, LeaveTable, PlaceBet, PlayerAction, Stand, TakeSeat,
@@ -58,7 +61,7 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
                             Ok(pid) => {
                                 // Only seed chips for new players (wallet returns Err if player unknown)
                                 if state.wallet.balance(pid).await.is_err() {
-                                    let _ = state.wallet.credit(pid, 1000).await;
+                                    let _ = state.wallet.credit(pid, NEW_PLAYER_CHIPS).await;
                                 }
                                 info!(
                                     "conn={conn_id} authenticated user='{}' player_id={}",
@@ -230,7 +233,24 @@ async fn handle_client_msg(
                     .await;
             }
 
-            // Reject join if the table refuses it
+            // Subscribe before joining so PlayerJoined event is never missed.
+            let mut rx = match state.session.subscribe(tid).await {
+                Ok(rx) => rx,
+                Err(e) => {
+                    error!("player={player_id} subscribe table={tid} failed: {e}");
+                    let _ = send_msg(
+                        socket,
+                        &ServerMessage::CommandError {
+                            request_id,
+                            reason: e.to_string(),
+                        },
+                    )
+                    .await;
+                    return Ok(());
+                }
+            };
+
+            // Then join — if rejected, the broadcast receiver is simply dropped.
             if let Err(e) = state
                 .session
                 .send_command(
@@ -254,24 +274,7 @@ async fn handle_client_msg(
             }
             info!("player={player_id} joined table={tid}");
 
-            // Subscribe FIRST to avoid missing events between snapshot and subscribe
-            let mut rx = match state.session.subscribe(tid).await {
-                Ok(rx) => rx,
-                Err(e) => {
-                    error!("player={player_id} subscribe table={tid} failed: {e}");
-                    let _ = send_msg(
-                        socket,
-                        &ServerMessage::CommandError {
-                            request_id,
-                            reason: e.to_string(),
-                        },
-                    )
-                    .await;
-                    return Ok(());
-                }
-            };
-
-            // Then snapshot
+            // Snapshot — on failure, undo the join so the actor state stays consistent.
             match state.session.snapshot(tid, player_id).await {
                 Ok(snap) => {
                     let _ = send_msg(
@@ -285,6 +288,15 @@ async fn handle_client_msg(
                 }
                 Err(e) => {
                     error!("player={player_id} snapshot table={tid} failed: {e}");
+                    let _ = state
+                        .session
+                        .send_command(
+                            tid,
+                            player_id,
+                            RequestId(0),
+                            PlayerAction::LeaveTable(LeaveTable { player_id }),
+                        )
+                        .await;
                     let _ = send_msg(
                         socket,
                         &ServerMessage::CommandError {


### PR DESCRIPTION
## Summary

- Replace stub `ws.rs` with the complete WebSocket handler (auth phase, post-auth command loop, event forwarder task, disconnect cleanup)
- `TakeSeat` converts `seat: u8` from wire to `Seat` via `TryFrom<u8>` added in PR-07; returns `CommandError` for out-of-range values (1–7)
- Subscribe-before-snapshot ordering in `JoinTable` to prevent event gap
- Event forwarder sends `Balance` update on `GameFinished`; handles lag with `CommandError` and aborts
- Wire up `list_tables` REST endpoint to the real `GameSession` (was returning empty vec)
- Update `openapi.json` golden file

## Test plan

- [ ] `cargo build -p server` passes
- [ ] `cargo test -p server` passes (including OpenAPI schema test)
- [ ] PR-07 server infra is the base