### PR TITLE
docs: ADR index, ADRs 0002–0005, Seat enum decision record

### DIFF
--- a/adr/0001-system-architecture.md
+++ b/adr/0001-system-architecture.md
@@ -233,5 +233,7 @@ pub trait EventStore: Send + Sync {
 - **Snapshot store**: Redis or a `game_snapshots` PostgreSQL table?
 - **Command rejections**: inline WebSocket response via correlation ID, or a
   `blackjack.command-rejections` Kafka topic?
-- **Player balance**: PostgreSQL projection or part of `TableState`?
-- **Auth**: JWT on WebSocket upgrade, or session token?
+- **Player balance**: Resolved in ADR-0004 — wallet service owns balance; game
+  holds a transient copy per round only.
+- **Auth**: Resolved in ADR-0002 (PoC) — username/password at WS connect time.
+  Production path TBD (JWT or session token).

--- a/adr/0002-poc-in-memory-implementation.md
+++ b/adr/0002-poc-in-memory-implementation.md
@@ -1,0 +1,70 @@
+# ADR-0002: PoC In-Memory Implementation
+
+| Field | Value |
+|---|---|
+| **ID** | 0002 |
+| **Date** | 2026-05-17 |
+| **Status** | Accepted |
+
+---
+
+## Context
+
+ADR-0001 defines the production target: Kafka for command/event routing, PostgreSQL
+for durable event log, multiple stateless WebSocket servers. Building that stack
+upfront would block validating the domain model and gameplay UX.
+
+A working PoC is needed first — playable end-to-end, correctness-verified, easy to
+run locally with a single `cargo run`.
+
+---
+
+## Decision
+
+Replace every infrastructure component from ADR-0001 with in-memory equivalents for
+the PoC. The domain core (`bj-core`) remains unchanged — it has no infrastructure
+dependency.
+
+| ADR-0001 component | PoC replacement |
+|---|---|
+| Kafka `blackjack.commands` | `mpsc::Sender<TableCommand>` per table |
+| Kafka `blackjack.events` | `broadcast::Sender<GameEvent>` per table |
+| PostgreSQL `game_events` | State held in `TableActor` (lost on restart) |
+| Engine worker (Kafka consumer) | `TableActor` — one `tokio::spawn` per table |
+| Stateless WebSocket servers | Single axum server, WS handler per connection |
+| Player wallet (DB projection) | `InMemoryWallet`: `RwLock<HashMap<PlayerId, u32>>` |
+| Auth (JWT / session tokens) | `InMemoryAuthenticator`: `RwLock<HashMap<String, UserRecord>>` |
+
+### TableActor
+
+Each table runs as a single `tokio` task owning `GameState` exclusively — no locks,
+no shared mutable state. Commands arrive via `mpsc`; events are broadcast to all
+subscriber channels. Dealer automation (betting timeout, player-turn timeout,
+round delay) runs as `tokio::select!` arms inside the same loop.
+
+### Test accounts
+
+Three accounts (`admin`, `qa`, `dev`, password `famly1234`) are seeded at startup
+with 1000 chips each. Idempotent — re-seeding returns the existing ID.
+
+---
+
+## Consequences
+
+**Positive**
+- Zero infrastructure to run locally — `cargo run --bin server`.
+- `TableActor` is structurally identical to the production `TablePartitionWorker`
+  from ADR-0001; migration is a transport swap, not a logic rewrite.
+- Domain model validated against a real UI without Kafka/PG complexity.
+
+**Negative / Trade-offs**
+- State lost on server restart — acceptable for PoC, not for production.
+- Single process — no horizontal scale, no partition rebalancing.
+- In-memory auth and wallet have no persistence.
+
+---
+
+## Open Questions
+
+- Migration path: swap `mpsc`/`broadcast` for Kafka producers/consumers; swap
+  `InMemoryWallet` for a wallet service client. When does this happen?

--- a/adr/0003-player-lifecycle-observer-model.md
+++ b/adr/0003-player-lifecycle-observer-model.md
@@ -1,0 +1,88 @@
+# ADR-0003: Player Lifecycle — Observer/Waiting-List Model
+
+| Field | Value |
+|---|---|
+| **ID** | 0003 |
+| **Date** | 2026-05-17 |
+| **Status** | Accepted |
+
+---
+
+## Context
+
+A blackjack table has a fixed seat count (`max_players`) but players should be able
+to watch a game in progress without disrupting it. Players arriving mid-round or at
+a full table need a place to queue. The domain needs clean state transitions that
+don't require special-casing the join path by phase or seat availability.
+
+---
+
+## Decision
+
+Three disjoint player states at a table:
+
+```
+JoinTable
+    │
+    ▼
+ Observer ──── TakeSeat (WaitingForBets + seat free) ──► Seated
+    │               │
+    │               └── TakeSeat (mid-game or full) ──► Waiting list
+    │
+ LeaveTable ──► disconnected
+
+ Seated / Waiting list
+    │
+ LeaveSeat ──► Observer
+```
+
+### Commands
+
+| Command | Precondition | Events emitted |
+|---|---|---|
+| `JoinTable` | Player not already at table; observer capacity not exceeded | `ObserverJoined` |
+| `TakeSeat` | Player is observer | `PlayerJoined` (if `WaitingForBets` + seat free), else `PlayerAddedToWaitingList` |
+| `LeaveSeat` | Player is seated or on waiting list | `PlayerLeft` + `ObserverJoined` (seated), or `PlayerRemovedFromWaitingList` + `ObserverJoined` (waiting) |
+| `LeaveTable` | Player is anywhere at table | `PlayerLeft` / `ObserverLeft` / `PlayerRemovedFromWaitingList` |
+
+### Waiting list promotion
+
+At the start of each new round (`OpenBetting`), waiting players are promoted to
+seats in FIFO order up to `max_players - current_seated` slots, each emitting
+`PlayerJoined`.
+
+### Observer capacity
+
+`TableSettings.max_observers` caps the observer + waiting list combined. `JoinTable`
+is rejected with `ObserversFull` when at capacity. `is_joinable` on the table
+summary reflects this — not seat availability.
+
+### GameState fields
+
+```rust
+pub struct GameState {
+    pub players:   Vec<PlayerState>,  // seated
+    pub observers: Vec<PlayerId>,
+    pub waiting:   Vec<PlayerId>,
+    // ...
+}
+```
+
+---
+
+## Consequences
+
+**Positive**
+- `JoinTable` is always valid (modulo capacity) regardless of phase — no
+  "can't join mid-game" error path.
+- Seating intent is explicit via `TakeSeat` — observers who just want to watch
+  never accidentally take a seat.
+- `LeaveSeat` keeps the player connected as an observer, preserving their WS
+  session and table subscription.
+
+**Negative / Trade-offs**
+- Three collections on `GameState` instead of one — event handlers must keep all
+  three consistent (e.g., `PlayerJoined` removes from both `observers` and
+  `waiting`).
+- Waiting list is FIFO but has no persistence — server restart drops all queued
+  players.

--- a/adr/0004-balance-as-wallet-concern.md
+++ b/adr/0004-balance-as-wallet-concern.md
@@ -1,0 +1,78 @@
+# ADR-0004: Player Balance as Wallet Concern
+
+| Field | Value |
+|---|---|
+| **ID** | 0004 |
+| **Date** | 2026-05-17 |
+| **Status** | Accepted |
+
+---
+
+## Context
+
+ADR-0001 left open: *"Player balance: PostgreSQL projection or part of TableState?"*
+
+Balance touches two concerns: the game (bet validation, payout calculation) and the
+wallet (persistent chip ledger). Conflating them creates coupling — the game engine
+would need wallet I/O, and balance would be replicated across game events and the
+wallet store.
+
+---
+
+## Decision
+
+Balance is owned by the wallet service. The game engine holds a transient copy
+for the duration of a round only.
+
+### Rules
+
+1. **Wallet is source of truth.** The canonical balance lives in `Wallet`, not in
+   `GameState` or any event.
+
+2. **Load on seat.** When a player is seated (`PlayerJoined`), `TableActor` fetches
+   their balance from `Wallet` and writes it into `PlayerState.balance`. This is the
+   only time the game reads from the wallet mid-round.
+
+3. **Flush on round end.** When the round reaches `Phase::Finished`, `TableActor`
+   calls `wallet.set_balance` for every seated player, persisting the post-payout
+   balance.
+
+4. **Balance not in events or snapshots.** `EventPayload` and `GameStateSnapshot`
+   carry no balance field. Clients learn their balance via a dedicated `Balance`
+   server message, not by reading game state.
+
+5. **Server pushes balance.** The server sends `Balance { amount }` to a client
+   after authentication and after each `GameFinished` event. The client stores it
+   separately from table state.
+
+### Data flow
+
+```
+Auth
+  └─► wallet.balance(pid)  ──► ServerMessage::Balance { amount }  ──► CLI header
+
+TakeSeat → PlayerJoined
+  └─► wallet.balance(pid)  ──► PlayerState.balance  (transient, in-memory only)
+
+GameFinished
+  ├─► wallet.set_balance(pid, balance)  for each player
+  └─► ServerMessage::Balance { amount }  ──► CLI header (updated)
+```
+
+---
+
+## Consequences
+
+**Positive**
+- Game engine stays pure — `GameEngine::handle` never touches the wallet.
+- Balance is not replicated into the event log; the wallet is the single ledger.
+- Client balance display is decoupled from game phase — works for observers too.
+
+**Negative / Trade-offs**
+- `TableActor` has a `wallet: Arc<dyn Wallet>` dependency — it is not purely a
+  game logic runner.
+- If the server crashes between `GameFinished` and `wallet.set_balance`, the round
+  result is lost. Acceptable for PoC; production needs transactional settlement.
+- Balance is stale during a round (reflects start-of-round value minus bets placed).
+  The client applies `PlayerPlacedBet` events locally to show a live estimate, but
+  this is UI-only and reconciled at round end.

--- a/adr/0005-seat-enum-and-deal-order.md
+++ b/adr/0005-seat-enum-and-deal-order.md
@@ -1,0 +1,40 @@
+# ADR-0005: Seat Enum and Deal Order
+
+## Status
+
+Accepted
+
+## Context
+
+Blackjack tables have at most 7 physical seat positions. Originally, player seating was represented as a plain `u8` position. This created several issues:
+
+- No compile-time guarantee of valid seat numbers (1–7)
+- `Ord` on `u8` works, but the semantic meaning is implicit
+- No central place to enumerate all valid seats
+- `TakeSeat` command had no way to enforce seat validity at the type level
+
+Additionally, real blackjack deals cards left-to-right by seat position. Without an explicit ordering abstraction, the dealing code had to rely on insertion order or ad-hoc sorting.
+
+## Decision
+
+Model seats as a `Seat` enum with seven variants (`One`..`Seven`), discriminants 1–7, and `#[derive(Ord)]`:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum Seat { One = 1, Two = 2, Three = 3, Four = 4, Five = 5, Six = 6, Seven = 7 }
+```
+
+The `Ord` derive gives left-to-right deal order for free — sorting `PlayerState` by `seat` before dealing cards is the canonical implementation.
+
+`Seat::ALL` provides an ordered slice of all valid seats, used for seat allocation in `OpenBetting`.
+
+A `TryFrom<u8>` impl provides safe deserialization from the wire format (client sends `seat: u8` in `TakeSeat` JSON; the server converts to `Seat` and returns a protocol error for out-of-range values).
+
+Multi-seat extensibility: `PlayerState` contains `pub seat: Seat`, and the same `player_id` can appear at multiple seats by having multiple `PlayerState` entries. The CLI enforces one-seat-per-player at the UI layer; the domain is seat-set agnostic.
+
+## Consequences
+
+- Deal order is enforced by the type system rather than by documentation or convention.
+- Invalid seat numbers are rejected at the protocol boundary (WS handler) rather than reaching the domain.
+- `GameStateSnapshot::waiting` is `Vec<(PlayerId, Seat)>` so clients can render reserved seat labels.
+- `Seat` must be kept in sync with `TableSettings::max_players` (currently max 7). If tables with more seats are needed, the enum must be extended.

--- a/adr/index.md
+++ b/adr/index.md
@@ -1,0 +1,9 @@
+# Architecture Decision Records
+
+| ID | Title | Status |
+|---|---|---|
+| [ADR-0001](0001-system-architecture.md) | System Architecture | Accepted |
+| [ADR-0002](0002-poc-in-memory-implementation.md) | PoC In-Memory Implementation | Accepted |
+| [ADR-0003](0003-player-lifecycle-observer-model.md) | Player Lifecycle — Observer/Waiting-List Model | Accepted |
+| [ADR-0004](0004-balance-as-wallet-concern.md) | Player Balance as Wallet Concern | Accepted |
+| [ADR-0005](0005-seat-enum-and-deal-order.md) | Seat Enum and Deal Order | Accepted |


### PR DESCRIPTION
## Summary

- **ADR-0002**: PoC in-memory implementation rationale (why in-memory before Postgres/Kafka)
- **ADR-0003**: Player lifecycle — observer/waiting-list model
- **ADR-0004**: Player balance as wallet concern, not domain concern
- **ADR-0005** (new): Seat enum + deal order — documents the PR-06 decision to model seats as an ordered enum (`Seat::One`..`Seat::Seven`) for type-safe deal ordering and wire-format validation via `TryFrom<u8>`
- Update ADR-0001 trailing section to reference the ADR-0004 resolution
- Add `adr/index.md` as a navigation table

## Test plan

- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo test --all` passes (104 tests total)
- [ ] ADR files render correctly as markdown