### PR TITLE
feat: Hetzner deployment – Docker, GitHub Actions CI/CD

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+target/
+.git/
+.github/
+blackjack-cli.log
+*.log

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,81 @@
+name: Deploy
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ghcr.io/skharchikov/blackjack-server
+  DEPLOY_HOST: 77.42.69.253
+  DEPLOY_DIR: /opt/blackjack-server
+
+jobs:
+  build-and-push:
+    name: Build & Push Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ env.IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy to Hetzner
+    runs-on: ubuntu-latest
+    needs: [build-and-push]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up SSH
+        env:
+          SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "${{ env.DEPLOY_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Copy docker-compose to server
+        run: |
+          rsync -az -e "ssh -i ~/.ssh/deploy_key" \
+            --include='docker-compose.yml' \
+            --exclude='*' \
+            ./ "deploy@${{ env.DEPLOY_HOST }}:${{ env.DEPLOY_DIR }}/"
+
+      - name: Pull image and restart
+        env:
+          GHCR_PAT: ${{ secrets.GHCR_PAT }}
+        run: |
+          ssh -i ~/.ssh/deploy_key \
+            -o ServerAliveInterval=15 \
+            -o ServerAliveCountMax=40 \
+            "deploy@${{ env.DEPLOY_HOST }}" \
+            "echo '$GHCR_PAT' | docker login ghcr.io -u skharchikov --password-stdin && \
+             cd ${{ env.DEPLOY_DIR }} && \
+             docker pull ${{ env.IMAGE }}:latest && \
+             docker compose up -d && \
+             docker compose logs --tail=20 server"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,9 @@ jobs:
     name: Deploy to Hetzner
     runs-on: ubuntu-latest
     needs: [build-and-push]
+    permissions:
+      contents: read
+      packages: read
     steps:
       - uses: actions/checkout@v4
 
@@ -68,13 +71,13 @@ jobs:
 
       - name: Pull image and restart
         env:
-          GHCR_PAT: ${{ secrets.GHCR_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ssh -i ~/.ssh/deploy_key \
             -o ServerAliveInterval=15 \
             -o ServerAliveCountMax=40 \
             "deploy@${{ env.DEPLOY_HOST }}" \
-            "echo '$GHCR_PAT' | docker login ghcr.io -u skharchikov --password-stdin && \
+            "echo '$GITHUB_TOKEN' | docker login ghcr.io -u ${{ github.actor }} --password-stdin && \
              cd ${{ env.DEPLOY_DIR }} && \
              docker pull ${{ env.IMAGE }}:latest && \
              docker compose up -d && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM rust:bookworm AS chef
+RUN cargo install cargo-chef --locked
+WORKDIR /app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+COPY . .
+RUN cargo build --release -p server
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=builder /app/target/release/server /app/server
+COPY server/configuration /app/server/configuration
+ENV APP_ENVIRONMENT=production
+EXPOSE 3000
+CMD ["/app/server"]

--- a/cli/src/app/state.rs
+++ b/cli/src/app/state.rs
@@ -33,7 +33,8 @@ impl App {
         Self {
             ui: UiState::login(),
             should_quit: false,
-            server_url: "http://127.0.0.1:3000".into(),
+            server_url: std::env::var("SERVER_URL")
+                .unwrap_or_else(|_| "http://127.0.0.1:3000".into()),
             player_id: Ulid::new().to_string(),
             username: String::new(),
             password: String::new(),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  server:
+    image: ghcr.io/skharchikov/blackjack-server:latest
+    ports:
+      - "8080:8080"
+    environment:
+      APP_ENVIRONMENT: production
+    restart: unless-stopped

--- a/server/configuration/production.yml
+++ b/server/configuration/production.yml
@@ -1,0 +1,3 @@
+application:
+  host: "0.0.0.0"
+  port: "8080"


### PR DESCRIPTION
## Summary

- Multi-stage Dockerfile with cargo-chef caching
- `docker-compose.yml` — single `server` service on port 8080
- `server/configuration/production.yml` — binds to `0.0.0.0:8080`
- `.github/workflows/deploy.yml` — build → push GHCR → SSH restart on `77.42.69.253`
- CLI respects `SERVER_URL` env var (default: `http://127.0.0.1:3000`)

## Required secrets

Add these in GitHub → Settings → Secrets:

| Secret | Value |
|--------|-------|
| `DEPLOY_SSH_KEY` | Private SSH key for `deploy@77.42.69.253` |
| `GHCR_PAT` | GitHub PAT with `read:packages` scope (for server-side `docker pull`) |

## Server setup (one-time)

```bash
# On 77.42.69.253
adduser deploy
usermod -aG docker deploy
mkdir -p /opt/blackjack-server
chown deploy:deploy /opt/blackjack-server
# Add public key to ~deploy/.ssh/authorized_keys
```

## CLI usage

```bash
SERVER_URL=http://77.42.69.253:8080 cargo run -p cli
```