### PR TITLE
ci: attach aarch64 CLI binary to cli releases for Raspberry Pi

### DIFF
--- a/.github/workflows/pi-binary.yml
+++ b/.github/workflows/pi-binary.yml
@@ -1,0 +1,62 @@
+# Why this exists: the CLI is played on a Raspberry Pi 4, and compiling the
+# workspace there takes ages (and requires a Rust toolchain on the Pi). This
+# workflow builds an aarch64 binary in CI whenever release-plz publishes a
+# cli-v* release and attaches it as a release asset, so the Pi only needs to
+# download and run it.
+#
+# Notes:
+# - Runs natively on GitHub's free arm64 runners (public repos only), so no
+#   cross-compilation toolchain is needed.
+# - Pinned to ubuntu-22.04-arm (glibc 2.35), not 24.04 (glibc 2.39): Raspberry
+#   Pi OS bookworm ships glibc 2.36, and the binary must not require a newer
+#   glibc than the Pi has.
+# - Assumes a 64-bit Pi OS. A 32-bit OS would need an armv7 build instead.
+name: Raspberry Pi binary
+
+on:
+  release:
+    types: [published]
+  # Manual backfill for releases published before this workflow existed,
+  # or re-runs after a failed upload.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing cli-v* release tag to build and upload for (e.g. cli-v0.1.1)"
+        required: true
+        type: string
+
+jobs:
+  build-and-upload:
+    name: Build aarch64 CLI & attach to release
+    # release-plz also publishes bj-core-v* / server-v* releases; only the CLI
+    # ships a user-facing binary, so skip everything else.
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'cli-v')
+    runs-on: ubuntu-22.04-arm
+    permissions:
+      contents: write
+    env:
+      TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TAG }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build CLI (release)
+        run: cargo build --release -p cli
+
+      - name: Package binary
+        # Tarball (rather than a bare binary) so the executable bit survives
+        # the download.
+        run: |
+          cp target/release/cli blackjack-cli
+          tar czf blackjack-cli-aarch64-linux.tar.gz blackjack-cli
+
+      - name: Upload to release
+        # --clobber makes manual re-runs idempotent.
+        run: gh release upload "$TAG" blackjack-cli-aarch64-linux.tar.gz --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ cargo run -p cli
 SERVER_URL=https://blackjack.skh.rs cargo run -p cli
 ```
 
+### Raspberry Pi (no compilation needed)
+
+Every `cli-v*` release ships a prebuilt aarch64 binary (built by
+[`pi-binary.yml`](.github/workflows/pi-binary.yml), requires a 64-bit Pi OS):
+
+Grab the newest `cli-v*` tag from the [releases page](https://github.com/skharchikov/blackjack/releases) (releases for other packages don't carry the binary), then:
+
+```bash
+curl -sL https://github.com/skharchikov/blackjack/releases/download/cli-v0.1.1/blackjack-cli-aarch64-linux.tar.gz | tar xz
+SERVER_URL=https://blackjack.skh.rs ./blackjack-cli
+```
+
 ### Accounts
 
 Enter any username + password on the login screen — the account is auto-created on first login. Same credentials on subsequent logins authenticate you.


### PR DESCRIPTION
## What

New workflow `pi-binary.yml`: when release-plz publishes a `cli-v*` release, build the CLI natively on GitHub's free arm64 runner (`ubuntu-22.04-arm`) and attach `blackjack-cli-aarch64-linux.tar.gz` as a release asset. README gains a Raspberry Pi quick-start section.

## Why

Playing the CLI on a Raspberry Pi 4 currently requires installing Rust and compiling the workspace on the Pi, which is very slow. With this, the Pi just downloads and runs the prebuilt binary.

## Details

- Native arm64 build — no cross-compilation toolchain, `native-tls` links against the runner's OpenSSL 3 (also what Pi OS bookworm ships).
- Pinned to `ubuntu-22.04-arm` (glibc 2.35) instead of 24.04 (2.39), so the binary runs on Pi OS bookworm (glibc 2.36).
- Skips `bj-core-v*` / `server-v*` releases — only the CLI ships a binary.
- `workflow_dispatch` with a `tag` input for backfilling existing releases and idempotent re-runs (`--clobber`).
- Assumes 64-bit Pi OS; a 32-bit install would need an armv7 build.

## Testing

Workflow only triggers on release publish, so after merge: run `gh workflow run pi-binary.yml -f tag=cli-v0.1.1` to backfill and verify end-to-end.