### PR TITLE
Add double down action

### DIFF
--- a/cli/src/app/keys.rs
+++ b/cli/src/app/keys.rs
@@ -167,6 +167,13 @@ fn handle_table_key(app: &mut App, key: KeyCode, tx: &mpsc::Sender<AppEvent>) {
                     let _ = ws_tx.try_send(msg.to_string());
                 }
             }
+            KeyCode::Char('d') => {
+                let rid = app.next_request_id();
+                if let (Some(ref ws_tx), Some(ref tid)) = (&app.ws_tx, &app.current_table_id) {
+                    let msg = serde_json::json!({"type": "DoubleDown", "table_id": tid, "request_id": rid});
+                    let _ = ws_tx.try_send(msg.to_string());
+                }
+            }
             _ => {}
         }
     }

--- a/cli/src/app/mod.rs
+++ b/cli/src/app/mod.rs
@@ -636,6 +636,15 @@ fn apply_event_payload(
                 }
                 table.log(format!("#{seq} {} bet {}", short_id(&pid), amount));
             }
+            EventPayload::PlayerDoubledDown { player, amount } => {
+                let pid = player.to_string();
+                if let Some(p) = table.players.iter_mut().find(|p| p.player_id == pid) {
+                    p.bet = Some(p.bet.unwrap_or(0) + amount);
+                    p.balance = p.balance.saturating_sub(amount);
+                    p.status = "doubled".into();
+                }
+                table.log(format!("#{seq} {} doubled (+{})", short_id(&pid), amount));
+            }
             EventPayload::GameStarted => {
                 for p in &mut table.players {
                     p.hand.cards.clear();

--- a/cli/src/ui/player_turn_popup.rs
+++ b/cli/src/ui/player_turn_popup.rs
@@ -65,19 +65,22 @@ pub fn render_player_turn_popup(frame: &mut Frame, area: Rect, ui: &UiState) {
 
     // Buttons
     let buttons = Line::from(vec![
-        Span::raw("  "),
         Span::styled(
             "[ H ] Hit",
             Style::default()
                 .fg(COLOR_GREEN)
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::raw("          "),
+        Span::raw("    "),
         Span::styled(
             "[ S ] Stand",
             Style::default().fg(COLOR_RED).add_modifier(Modifier::BOLD),
         ),
-        Span::raw("  "),
+        Span::raw("    "),
+        Span::styled(
+            "[ D ] Double",
+            Style::default().fg(COLOR_CYAN).add_modifier(Modifier::BOLD),
+        ),
     ]);
     frame.render_widget(
         Paragraph::new(buttons).alignment(Alignment::Center),

--- a/core/src/domain/engine/action.rs
+++ b/core/src/domain/engine/action.rs
@@ -2,4 +2,5 @@
 pub enum PlayerDecision {
     Hit,
     Stand,
+    Double,
 }

--- a/core/src/domain/engine/command/player/double_down.rs
+++ b/core/src/domain/engine/command/player/double_down.rs
@@ -1,0 +1,306 @@
+use crate::domain::{
+    engine::{
+        action::PlayerDecision, command::CommandHandler, error::CommandError,
+        event::payload::EventPayload, game_state::GameState, phase::Phase,
+    },
+    player::PlayerId,
+    table::TableSettings,
+};
+
+#[derive(Debug, Clone)]
+pub struct DoubleDown {
+    pub player_id: PlayerId,
+}
+
+impl CommandHandler for DoubleDown {
+    fn handle(
+        &self,
+        state: &GameState,
+        _settings: &TableSettings,
+    ) -> Result<Vec<EventPayload>, CommandError> {
+        match &state.phase {
+            Phase::PlayerTurn(id) if *id == self.player_id => {}
+            _ => return Err(CommandError::NotPlayersTurn),
+        }
+        let player = state
+            .player(self.player_id)
+            .ok_or(CommandError::PlayerNotFound(self.player_id))?;
+
+        // Double down is only allowed on the initial two-card hand.
+        if player.hand.cards.len() != 2 {
+            return Err(CommandError::CannotDoubleDown);
+        }
+
+        let bet = player.bet.ok_or(CommandError::CannotDoubleDown)?;
+        if player.balance < bet {
+            return Err(CommandError::InsufficientBalance {
+                balance: player.balance,
+                amount: bet,
+            });
+        }
+
+        let card = state.next_card().ok_or(CommandError::ShoeEmpty)?;
+
+        let mut events = vec![
+            EventPayload::PlayerDoubledDown {
+                player: self.player_id,
+                amount: bet,
+            },
+            EventPayload::PlayerCardDealt {
+                player: self.player_id,
+                card,
+            },
+            EventPayload::PlayerDecisionTaken {
+                player: self.player_id,
+                action: PlayerDecision::Double,
+            },
+        ];
+
+        let mut new_hand = player.hand.clone();
+        new_hand.add_card(card);
+        if new_hand.value().is_bust() {
+            events.push(EventPayload::PlayerBust {
+                player: self.player_id,
+            });
+        }
+
+        events.push(EventPayload::PhaseChanged {
+            from: Phase::PlayerTurn(self.player_id),
+            to: state.next_player_after(self.player_id),
+        });
+
+        Ok(events)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        dealer::DealerId,
+        engine::{
+            action::PlayerDecision,
+            command::{
+                player::{PlayerAction, PlayerCommand},
+                CommandId, GameCommand,
+            },
+            game_id::GameId,
+            game_state::GameState,
+            phase::Phase,
+            GameEngine,
+        },
+        player::PlayerId,
+        table::TableSettings,
+        Card, DeckId, Rank, Suit,
+    };
+
+    fn settings() -> TableSettings {
+        TableSettings {
+            min_bet: 10,
+            max_bet: 500,
+            max_players: 5,
+            max_observers: 10,
+        }
+    }
+
+    fn card(rank: Rank) -> Card {
+        Card {
+            deck_id: DeckId::One,
+            rank,
+            suit: Suit::Spades,
+        }
+    }
+
+    fn double_cmd(pid: PlayerId) -> GameCommand {
+        GameCommand::Player(PlayerCommand {
+            game_id: GameId::new(),
+            command_id: CommandId(0),
+            action: PlayerAction::DoubleDown(DoubleDown { player_id: pid }),
+        })
+    }
+
+    fn state_in_player_turn(
+        pid: PlayerId,
+        hand_ranks: Vec<Rank>,
+        next_card_rank: Rank,
+        bet: u32,
+        balance: u32,
+    ) -> GameState {
+        let mut shoe: Vec<Card> = vec![card(next_card_rank)];
+        shoe.extend(vec![card(Rank::Two); 20]);
+
+        let mut state =
+            GameState::new_with_balance(GameId::new(), shoe, vec![(pid, balance)], DealerId::new());
+        state.players[0].bet = Some(bet);
+        for r in hand_ranks {
+            state.players[0].hand.add_card(card(r));
+        }
+        state.phase = Phase::PlayerTurn(pid);
+        state
+    }
+
+    #[test]
+    fn double_deals_one_card_and_stands() {
+        let pid = PlayerId::new();
+        // Two + Three = 5, next Four -> 9, no bust
+        let state = state_in_player_turn(pid, vec![Rank::Two, Rank::Three], Rank::Four, 100, 1000);
+        let events = GameEngine::handle(&state, &settings(), &double_cmd(pid)).unwrap();
+        // DoubledDown + CardDealt + DecisionTaken(Double) + PhaseChanged
+        assert_eq!(events.len(), 4);
+        assert!(matches!(
+            events[0],
+            EventPayload::PlayerDoubledDown { amount: 100, .. }
+        ));
+        assert!(matches!(events[1], EventPayload::PlayerCardDealt { .. }));
+        assert!(matches!(
+            events[2],
+            EventPayload::PlayerDecisionTaken {
+                action: PlayerDecision::Double,
+                ..
+            }
+        ));
+        assert!(matches!(events[3], EventPayload::PhaseChanged { .. }));
+    }
+
+    #[test]
+    fn double_doubles_bet_and_deducts_balance() {
+        let pid = PlayerId::new();
+        let mut state =
+            state_in_player_turn(pid, vec![Rank::Two, Rank::Three], Rank::Four, 100, 1000);
+        let events = GameEngine::handle(&state, &settings(), &double_cmd(pid)).unwrap();
+        for e in &events {
+            state.apply_event(e);
+        }
+        assert_eq!(state.players[0].bet, Some(200));
+        assert_eq!(state.players[0].balance, 900);
+    }
+
+    #[test]
+    fn double_causes_bust() {
+        let pid = PlayerId::new();
+        // King(10) + Queen(10) = 20, next Five(5) -> 25 bust
+        let state = state_in_player_turn(pid, vec![Rank::King, Rank::Queen], Rank::Five, 100, 1000);
+        let events = GameEngine::handle(&state, &settings(), &double_cmd(pid)).unwrap();
+        // DoubledDown + CardDealt + DecisionTaken + Bust + PhaseChanged
+        assert_eq!(events.len(), 5);
+        assert!(matches!(events[3], EventPayload::PlayerBust { .. }));
+        assert!(matches!(events[4], EventPayload::PhaseChanged { .. }));
+    }
+
+    #[test]
+    fn double_wrong_turn() {
+        let pid = PlayerId::new();
+        let other = PlayerId::new();
+        let state = state_in_player_turn(pid, vec![Rank::Two, Rank::Three], Rank::Four, 100, 1000);
+        assert!(matches!(
+            GameEngine::handle(&state, &settings(), &double_cmd(other)),
+            Err(CommandError::NotPlayersTurn)
+        ));
+    }
+
+    #[test]
+    fn double_not_two_cards() {
+        let pid = PlayerId::new();
+        // three cards in hand -> cannot double
+        let state = state_in_player_turn(
+            pid,
+            vec![Rank::Two, Rank::Three, Rank::Four],
+            Rank::Five,
+            100,
+            1000,
+        );
+        assert!(matches!(
+            GameEngine::handle(&state, &settings(), &double_cmd(pid)),
+            Err(CommandError::CannotDoubleDown)
+        ));
+    }
+
+    #[test]
+    fn double_then_win_pays_out_on_doubled_stake() {
+        use crate::domain::engine::command::dealer::{DealerAction, DealerCommand, SettleRound};
+
+        let pid = PlayerId::new();
+        // Player: Six + Five = 11, doubles, draws Nine -> 20.
+        let mut state =
+            state_in_player_turn(pid, vec![Rank::Six, Rank::Five], Rank::Nine, 100, 1000);
+        // Balance after the original bet was placed: place_bet already deducted it.
+        state.players[0].balance = 900;
+
+        let events = GameEngine::handle(&state, &settings(), &double_cmd(pid)).unwrap();
+        for e in &events {
+            state.apply_event(e);
+        }
+        // Stake doubled to 200, balance now 800.
+        assert_eq!(state.players[0].bet, Some(200));
+        assert_eq!(state.players[0].balance, 800);
+
+        // Dealer stands on 18; player 20 wins.
+        state.dealer.hand.add_card(card(Rank::King));
+        state.dealer.hand.add_card(card(Rank::Eight));
+        state.phase = Phase::Payouts;
+
+        let settle = GameCommand::Dealer(DealerCommand {
+            game_id: GameId::new(),
+            command_id: CommandId(0),
+            action: DealerAction::SettleRound(SettleRound),
+        });
+        let settle_events = GameEngine::handle(&state, &settings(), &settle).unwrap();
+        for e in &settle_events {
+            state.apply_event(e);
+        }
+        // Win pays 2x the 200 stake = 400 credited; 800 + 400 = 1200.
+        assert_eq!(state.players[0].balance, 1200);
+    }
+
+    #[test]
+    fn double_advances_to_next_player() {
+        let p1 = PlayerId::new();
+        let p2 = PlayerId::new();
+        let mut shoe: Vec<Card> = vec![card(Rank::Four)];
+        shoe.extend(vec![card(Rank::Two); 20]);
+        let mut state = GameState::new_with_balance(
+            GameId::new(),
+            shoe,
+            vec![(p1, 1000), (p2, 1000)],
+            DealerId::new(),
+        );
+        state.players[0].bet = Some(100);
+        state.players[0].hand.add_card(card(Rank::Two));
+        state.players[0].hand.add_card(card(Rank::Three));
+        state.players[1].bet = Some(100);
+        state.phase = Phase::PlayerTurn(p1);
+
+        let events = GameEngine::handle(&state, &settings(), &double_cmd(p1)).unwrap();
+        let last = events.last().unwrap();
+        assert!(
+            matches!(last, EventPayload::PhaseChanged { to: Phase::PlayerTurn(id), .. } if *id == p2)
+        );
+    }
+
+    #[test]
+    fn double_with_no_bet_placed() {
+        let pid = PlayerId::new();
+        // In PlayerTurn with a two-card hand but no bet -> cannot double.
+        let mut state =
+            state_in_player_turn(pid, vec![Rank::Two, Rank::Three], Rank::Four, 100, 1000);
+        state.players[0].bet = None;
+        assert!(matches!(
+            GameEngine::handle(&state, &settings(), &double_cmd(pid)),
+            Err(CommandError::CannotDoubleDown)
+        ));
+    }
+
+    #[test]
+    fn double_insufficient_balance() {
+        let pid = PlayerId::new();
+        // bet 100 but balance only 50 -> cannot cover the doubled stake
+        let state = state_in_player_turn(pid, vec![Rank::Two, Rank::Three], Rank::Four, 100, 50);
+        assert!(matches!(
+            GameEngine::handle(&state, &settings(), &double_cmd(pid)),
+            Err(CommandError::InsufficientBalance {
+                balance: 50,
+                amount: 100
+            })
+        ));
+    }
+}

--- a/core/src/domain/engine/command/player/hit.rs
+++ b/core/src/domain/engine/command/player/hit.rs
@@ -24,9 +24,7 @@ impl CommandHandler for Hit {
         }
         let card = state.next_card().ok_or(CommandError::ShoeEmpty)?;
         let player = state
-            .players
-            .iter()
-            .find(|p| p.player_id == self.player_id)
+            .player(self.player_id)
             .ok_or(CommandError::PlayerNotFound(self.player_id))?;
 
         let mut events = vec![EventPayload::PlayerCardDealt {

--- a/core/src/domain/engine/command/player/mod.rs
+++ b/core/src/domain/engine/command/player/mod.rs
@@ -1,3 +1,4 @@
+pub mod double_down;
 pub mod hit;
 pub mod join_table;
 pub mod leave_seat;
@@ -6,6 +7,7 @@ pub mod place_bet;
 pub mod stand;
 pub mod take_seat;
 
+pub use double_down::DoubleDown;
 pub use hit::Hit;
 pub use join_table::JoinTable;
 pub use leave_seat::LeaveSeat;
@@ -30,6 +32,7 @@ pub struct PlayerCommand {
 
 #[derive(Debug, Clone)]
 pub enum PlayerAction {
+    DoubleDown(DoubleDown),
     Hit(Hit),
     JoinTable(JoinTable),
     LeaveSeat(LeaveSeat),
@@ -46,6 +49,7 @@ impl CommandHandler for PlayerAction {
         settings: &TableSettings,
     ) -> Result<Vec<EventPayload>, CommandError> {
         match self {
+            Self::DoubleDown(h) => h.handle(state, settings),
             Self::Hit(h) => h.handle(state, settings),
             Self::JoinTable(h) => h.handle(state, settings),
             Self::LeaveSeat(h) => h.handle(state, settings),

--- a/core/src/domain/engine/command/player/place_bet.rs
+++ b/core/src/domain/engine/command/player/place_bet.rs
@@ -25,9 +25,7 @@ impl CommandHandler for PlaceBet {
             });
         }
         let player = state
-            .players
-            .iter()
-            .find(|p| p.player_id == self.player_id)
+            .player(self.player_id)
             .ok_or(CommandError::PlayerNotFound(self.player_id))?;
         if player.bet.is_some() {
             return Err(CommandError::AlreadyPlacedBet);

--- a/core/src/domain/engine/error.rs
+++ b/core/src/domain/engine/error.rs
@@ -17,6 +17,8 @@ pub enum CommandError {
     InsufficientBalance { balance: u32, amount: u32 },
     #[error("player already placed a bet this round")]
     AlreadyPlacedBet,
+    #[error("double down is only allowed on the initial two-card hand")]
+    CannotDoubleDown,
     #[error("shoe is empty")]
     ShoeEmpty,
     #[error("table is full")]

--- a/core/src/domain/engine/event/payload.rs
+++ b/core/src/domain/engine/event/payload.rs
@@ -33,6 +33,11 @@ pub enum EventPayload {
         player: PlayerId,
         amount: u32,
     },
+    /// Player doubled their stake; `amount` is the additional bet matching the original.
+    PlayerDoubledDown {
+        player: PlayerId,
+        amount: u32,
+    },
     GameStarted,
     PhaseChanged {
         from: Phase,

--- a/core/src/domain/engine/game_state.rs
+++ b/core/src/domain/engine/game_state.rs
@@ -73,6 +73,16 @@ impl GameState {
         }
     }
 
+    /// Returns the player with the given id, if seated at this table.
+    pub fn player(&self, id: PlayerId) -> Option<&PlayerState> {
+        self.players.iter().find(|p| p.player_id == id)
+    }
+
+    /// Returns a mutable reference to the player with the given id, if seated at this table.
+    pub fn player_mut(&mut self, id: PlayerId) -> Option<&mut PlayerState> {
+        self.players.iter_mut().find(|p| p.player_id == id)
+    }
+
     /// Returns the next card to be dealt from the shoe, without advancing the cursor.
     pub fn next_card(&self) -> Option<Card> {
         self.shoe.get(self.dealt).copied()
@@ -107,10 +117,15 @@ impl GameState {
                 self.waiting.retain(|(p, _)| *p != *player);
             }
             EventPayload::PlayerPlacedBet { player, amount } => {
-                if let Some(player_state) = self.players.iter_mut().find(|p| p.player_id == *player)
-                {
+                if let Some(player_state) = self.player_mut(*player) {
                     player_state.balance = player_state.balance.saturating_sub(*amount);
                     player_state.bet = Some(*amount);
+                }
+            }
+            EventPayload::PlayerDoubledDown { player, amount } => {
+                if let Some(player_state) = self.player_mut(*player) {
+                    player_state.balance = player_state.balance.saturating_sub(*amount);
+                    player_state.bet = player_state.bet.map(|b| b + *amount);
                 }
             }
             EventPayload::GameStarted => {
@@ -122,19 +137,19 @@ impl GameState {
             EventPayload::GameFinished { result } => {
                 self.phase = Phase::Finished;
                 for player_result in &result.player_results {
-                    if let Some(player_state) = self
-                        .players
-                        .iter_mut()
-                        .find(|p| p.player_id == player_result.player)
-                    {
+                    if let Some(player_state) = self.player_mut(player_result.player) {
                         player_state.balance += player_result.payout.total();
                     }
                 }
             }
             EventPayload::PlayerCardDealt { player, card } => {
-                if let Some(player_state) = self.players.iter_mut().find(|p| p.player_id == *player)
+                // Increment the deal cursor only when the card was actually dealt to a
+                // seated player, matching the original inline lookup's behaviour.
+                if self
+                    .player_mut(*player)
+                    .map(|p| p.hand.add_card(*card))
+                    .is_some()
                 {
-                    player_state.hand.add_card(*card);
                     self.dealt += 1;
                 }
             }
@@ -154,8 +169,7 @@ impl GameState {
                 // State already has the card; this event exists only to inform clients.
             }
             EventPayload::PlayerDecisionTaken { player, action } => {
-                if let Some(player_state) = self.players.iter_mut().find(|p| p.player_id == *player)
-                {
+                if let Some(player_state) = self.player_mut(*player) {
                     player_state.decisions.push(*action);
                 }
             }
@@ -192,7 +206,11 @@ impl GameState {
 
     pub fn player_finished(&self, p: &PlayerState) -> bool {
         use crate::domain::engine::action::PlayerDecision;
-        p.hand.value().is_bust() || p.decisions.last() == Some(&PlayerDecision::Stand)
+        p.hand.value().is_bust()
+            || matches!(
+                p.decisions.last(),
+                Some(&PlayerDecision::Stand) | Some(&PlayerDecision::Double)
+            )
     }
 
     pub fn first_betting_player(&self) -> Option<PlayerId> {

--- a/server/src/protocol/mod.rs
+++ b/server/src/protocol/mod.rs
@@ -34,6 +34,10 @@ pub enum ClientMessage {
         table_id: String,
         request_id: u64,
     },
+    DoubleDown {
+        table_id: String,
+        request_id: u64,
+    },
     TakeSeat {
         table_id: String,
         request_id: u64,

--- a/server/src/routes/ws.rs
+++ b/server/src/routes/ws.rs
@@ -20,7 +20,7 @@ use crate::{
 const NEW_PLAYER_CHIPS: u32 = 1_000;
 use bj_core::domain::{
     engine::command::player::{
-        Hit, JoinTable, LeaveSeat, LeaveTable, PlaceBet, PlayerAction, Stand, TakeSeat,
+        DoubleDown, Hit, JoinTable, LeaveSeat, LeaveTable, PlaceBet, PlayerAction, Stand, TakeSeat,
     },
     engine::snapshot::GameEventDto,
     Seat, TableId,
@@ -456,6 +456,20 @@ async fn handle_client_msg(
                 &table_id,
                 request_id,
                 PlayerAction::Stand(Stand { player_id }),
+            )
+            .await?;
+        }
+        ClientMessage::DoubleDown {
+            table_id,
+            request_id,
+        } => {
+            send_player_cmd(
+                socket,
+                state,
+                player_id,
+                &table_id,
+                request_id,
+                PlayerAction::DoubleDown(DoubleDown { player_id }),
             )
             .await?;
         }


### PR DESCRIPTION
### Reason for changes

`double down` was the one standard blackjack action missing from the player's turn. This adds it end to end so a player can commit an extra unit on a strong opening hand.

### Notable changes

- New `DoubleDown` command (`core/.../player/double_down.rs`): allowed only on the opening two-card hand, doubles the stake, deals exactly one card, then auto-stands (busting past 21). Rejects acting out of turn (`NotPlayersTurn`), a hand past two cards or no bet (`CannotDoubleDown`), and a stake the balance can't cover (`InsufficientBalance`).
- New `PlayerDoubledDown` event; the doubled `bet` flows through the existing `SettleRound` path, so a win pays out on the larger stake with no settlement changes.
- `player_finished` now treats a trailing `Double` decision as terminal.
- Server `ClientMessage::DoubleDown` + websocket dispatch; CLI `d` key, popup `[ D ] Double` button (button row re-spaced to fit), and event-log line.
- Refactor: added `GameState::player` / `player_mut` helpers and routed every by-id player lookup through them.

### Testing

Unit-tested the command handler in isolation via `GameEngine::handle`: happy path (one card + auto-stand), bust, multi-player turn advancement, and every rejection branch (wrong turn, >2 cards, no bet, insufficient balance). One end-to-end test drives double → settle and asserts the payout lands on the doubled stake. Full workspace `cargo test` and `cargo fmt --check` are green.

### Blocked by